### PR TITLE
fix typo in select_outputs variable

### DIFF
--- a/batch/inference_job_launcher.py
+++ b/batch/inference_job_launcher.py
@@ -714,7 +714,7 @@ class BatchJobHandler(object):
                 slurm_job_id = stdout.decode().split(" ")[-1][:-1]
                 print(f">>> SUCCESS SCHEDULING JOB. Slurm job id is {slurm_job_id}")
 
-                postprod_command = f"""sbatch {export_str} --dependency=afterany:{slurm_job_id} --mem={32000}M --time={120} --job-name=post-{cur_job_name} {os.path.dirname(os.path.realpath(__file__))}/SLURM_postprocess_runner.run"""
+                postprod_command = f"""sbatch {export_str} --dependency=afterany:{slurm_job_id} --mem={12000}M --time={60} --job-name=post-{cur_job_name} {os.path.dirname(os.path.realpath(__file__))}/SLURM_postprocess_runner.run"""
                 print("post-processing command to be run >>>>>>>> ")
                 print(postprod_command)
                 print(" <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< ")

--- a/postprocessing/postprocess_snapshot.R
+++ b/postprocessing/postprocess_snapshot.R
@@ -20,7 +20,7 @@ option_list = list(
   optparse::make_option(c("-u","--run-id"), action="store", dest = "run_id", type='character', help="Unique identifier for this run", default = Sys.getenv("FLEPI_RUN_INDEX",covidcommon::run_id())),
   optparse::make_option(c("-R", "--results-path"), action="store", dest = "results_path",  type='character', help="Path for model output", default = Sys.getenv("FS_RESULTS_PATH", Sys.getenv("FS_RESULTS_PATH"))),
   optparse::make_option(c("-p", "--flepimop-repo"), action="store", dest = "flepimop_repo", default=Sys.getenv("FLEPI_PATH", Sys.getenv("FLEPI_PATH")), type='character', help="path to the flepimop repo"),
-  optparse::make_option(c("-o", "--select-outputs"), action="store", dest = "select_outputs", default=Sys.getenv("OUTPUTS",c("hosp", "snpi", "llik")), type='character', help="path to the flepimop repo")
+  optparse::make_option(c("-o", "--select-outputs"), action="store", dest = "select_outputs", default=Sys.getenv("OUTPUTS","hosp, snpi, hnpi, llik"), type='character', help="path to the flepimop repo")
 )
 
 parser=optparse::OptionParser(option_list=option_list)
@@ -52,6 +52,8 @@ if(opt$flepimop_repo == ""){
 
 print(paste('Processing run ',opt$results_path))
 
+opt$select_outputs <- strsplit(opt$select_outputs, ', ')[[1]]
+print(opt$select_outputs)
 ## SETUP -----------------------------------------------------------------------
 
 config <- covidcommon::load_config(opt$config)


### PR DESCRIPTION
Fixed select-outputs environmental variable. 

Outputs you desire a snapshot of must be read in as "hosp, snpi, hnpi" etc, with a ', ' separating each output. 