### PR TITLE
Sub-project: effect of evolution on projections, some edits

### DIFF
--- a/batch/SLURM_inference_job.run
+++ b/batch/SLURM_inference_job.run
@@ -99,6 +99,7 @@ if [[ $FLEPI_CONTINUATION == "TRUE" ]]; then
     else
         echo "CONTINUATION: Could not copy file of type $filetype ($IN_FILENAME -> $INIT_FILENAME)"
     fi
+    Rscript $FLEPI_PATH/preprocessing/seir_recode_omicron.R --res_config config_SMH_R17_noBoo_lowIE_phase2_blk2_evo.yml
     #Rscript $FLEPI_PATH/flepimop/main_scripts/seir_init_immuneladder.R --res_config config_SMH_R17_noBoo_lowIE_phase2_blk2.yml
     #Rscript $FLEPI_PATH/preprocessing/seir_init_immuneladder_r17phase3_preOm.R --res_config config_SMH_R17_noBoo_lowIE_phase2_blk2.yml
 fi

--- a/batch/SLURM_inference_job.run
+++ b/batch/SLURM_inference_job.run
@@ -100,7 +100,7 @@ if [[ $FLEPI_CONTINUATION == "TRUE" ]]; then
         echo "CONTINUATION: Could not copy file of type $filetype ($IN_FILENAME -> $INIT_FILENAME)"
     fi
     export IN_SEED_FILENAME=$(python -c "from gempyor import file_paths; print(file_paths.create_file_name('$FLEPI_RUN_INDEX','$FLEPI_PREFIX/$FLEPI_RUN_INDEX/global/intermediate/%09d.'% $FLEPI_SLOT_INDEX,$FLEPI_BLOCK_INDEX-1,'seed','csv'))")
-    Rscript $FLEPI_PATH/preprocessing/seir_recode_omicron.R --res_config config_SMH_R17_noBoo_lowIE_phase2_blk2_evo.yml
+    #Rscript $FLEPI_PATH/preprocessing/seir_recode_omicron.R --res_config config_SMH_R17_noBoo_lowIE_phase2_blk2_evo.yml #--recode_variant $RECODE_VAR
     #Rscript $FLEPI_PATH/flepimop/main_scripts/seir_init_immuneladder.R --res_config config_SMH_R17_noBoo_lowIE_phase2_blk2.yml
     #Rscript $FLEPI_PATH/preprocessing/seir_init_immuneladder_r17phase3_preOm.R --res_config config_SMH_R17_noBoo_lowIE_phase2_blk2.yml
 fi

--- a/batch/SLURM_inference_job.run
+++ b/batch/SLURM_inference_job.run
@@ -100,6 +100,7 @@ if [[ $FLEPI_CONTINUATION == "TRUE" ]]; then
         echo "CONTINUATION: Could not copy file of type $filetype ($IN_FILENAME -> $INIT_FILENAME)"
     fi
     export IN_SEED_FILENAME=$(python -c "from gempyor import file_paths; print(file_paths.create_file_name('$FLEPI_RUN_INDEX','$FLEPI_PREFIX/$FLEPI_RUN_INDEX/global/intermediate/%09d.'% $FLEPI_SLOT_INDEX,$FLEPI_BLOCK_INDEX-1,'seed','csv'))")
+    Rscript $FLEPI_PATH/preprocessing/seir_recode_omicron.R --res_config config_SMH_R17_noBoo_lowIE_phase3_blk2_variant_deltainf.yml #--recode_variant $RECODE_VAR
     #Rscript $FLEPI_PATH/preprocessing/seir_recode_omicron.R --res_config config_SMH_R17_noBoo_lowIE_phase2_blk2_evo.yml #--recode_variant $RECODE_VAR
     #Rscript $FLEPI_PATH/flepimop/main_scripts/seir_init_immuneladder.R --res_config config_SMH_R17_noBoo_lowIE_phase2_blk2.yml
     #Rscript $FLEPI_PATH/preprocessing/seir_init_immuneladder_r17phase3_preOm.R --res_config config_SMH_R17_noBoo_lowIE_phase2_blk2.yml

--- a/batch/SLURM_inference_job.run
+++ b/batch/SLURM_inference_job.run
@@ -99,6 +99,7 @@ if [[ $FLEPI_CONTINUATION == "TRUE" ]]; then
     else
         echo "CONTINUATION: Could not copy file of type $filetype ($IN_FILENAME -> $INIT_FILENAME)"
     fi
+    export IN_SEED_FILENAME=$(python -c "from gempyor import file_paths; print(file_paths.create_file_name('$FLEPI_RUN_INDEX','$FLEPI_PREFIX/$FLEPI_RUN_INDEX/global/intermediate/%09d.'% $FLEPI_SLOT_INDEX,$FLEPI_BLOCK_INDEX-1,'seed','csv'))")
     Rscript $FLEPI_PATH/preprocessing/seir_recode_omicron.R --res_config config_SMH_R17_noBoo_lowIE_phase2_blk2_evo.yml
     #Rscript $FLEPI_PATH/flepimop/main_scripts/seir_init_immuneladder.R --res_config config_SMH_R17_noBoo_lowIE_phase2_blk2.yml
     #Rscript $FLEPI_PATH/preprocessing/seir_init_immuneladder_r17phase3_preOm.R --res_config config_SMH_R17_noBoo_lowIE_phase2_blk2.yml

--- a/preprocessing/seir_recode_omicron.R
+++ b/preprocessing/seir_recode_omicron.R
@@ -26,7 +26,7 @@ option_list <- list(
   optparse::make_option(c("--res_config"), action = "store", default = Sys.getenv("RESUMED_CONFIG_PATH", NA), type = "character", help = "path to the previous config file"),
   optparse::make_option(c("-c", "--config"), action = "store", default = Sys.getenv("CONFIG_PATH"), type = "character", help = "path to the config file"),
   optparse::make_option(c("-p", "--flepi_path"), action="store", type='character', default = Sys.getenv("FLEPI_PATH", "flepiMoP/"), help="path to the flepiMoP directory"),
-  optparse::make_option(c("-v", "--recode_variant"), action="store", type='character', default = Sys.getenv("RECODE_VAR", "OMICRON"), help="variant you want to change all variant_types to"),
+  optparse::make_option(c("-v", "--recode_variant"), action="store", type='character', default = Sys.getenv("RECODE_VAR", "DELTA"), help="variant you want to change all variant_types to"),
   optparse::make_option(c("--in_filename"), action="store", type='character', default = Sys.getenv("IN_FILENAME"), help="seir file global intermediate name"), # This is the CONTINUED SEIR filename
   optparse::make_option(c("--in_seed_filename"), action="store", type='character', default = Sys.getenv("IN_SEED_FILENAME"), help="seed file global intermediate name"), # This is the CONTINUED SEED filename
   optparse::make_option(c("--init_filename"), action="store", type='character', default = Sys.getenv("INIT_FILENAME"), help="init file global intermediate name") # This is the new init filename
@@ -76,7 +76,8 @@ seir_dt <- continued_seir %>% mutate(date = lubridate::as_date(date))  %>%
   filter(mc_value_type == "prevalence") %>%
   filter(date == transition_date) %>%
   pivot_longer(cols = -c(starts_with("mc_"), date), names_to = "geoid", values_to = "value") %>%
-  mutate(mc_variant_type = opt$recode_variant) %>%
+  #mutate(mc_variant_type = opt$recode_variant) %>%
+  mutate(mc_variant_type = ifelse(mc_variant_type %in% c("WILD","ALPHA"),"DELTA",mc_variant_type)) %>% 
   group_by(across(c(-value))) %>%
   summarise(value = sum(value, na.rm = TRUE)) %>%  
   dplyr::mutate(mc_name = paste(mc_infection_stage, mc_vaccination_stage, mc_variant_type, mc_age_strata, sep = "_")) %>%

--- a/preprocessing/seir_recode_omicron.R
+++ b/preprocessing/seir_recode_omicron.R
@@ -26,6 +26,7 @@ option_list <- list(
   optparse::make_option(c("--res_config"), action = "store", default = Sys.getenv("RESUMED_CONFIG_PATH", NA), type = "character", help = "path to the previous config file"),
   optparse::make_option(c("-c", "--config"), action = "store", default = Sys.getenv("CONFIG_PATH"), type = "character", help = "path to the config file"),
   optparse::make_option(c("-p", "--flepi_path"), action="store", type='character', default = Sys.getenv("FLEPI_PATH", "flepiMoP/"), help="path to the flepiMoP directory"),
+  optparse::make_option(c("-v", "--recode_variant"), action="store", type='character', default = Sys.getenv("RECODE_VAR", "OMICRON"), help="variant you want to change all variant_types to"),
   optparse::make_option(c("--in_filename"), action="store", type='character', default = Sys.getenv("IN_FILENAME"), help="seir file global intermediate name"), # This is the CONTINUED SEIR filename
   optparse::make_option(c("--init_filename"), action="store", type='character', default = Sys.getenv("INIT_FILENAME"), help="init file global intermediate name") # This is the new init filename
   )
@@ -71,7 +72,7 @@ seir_dt <- continued_seir %>% mutate(date = lubridate::as_date(date))  %>%
   filter(mc_value_type == "prevalence") %>%
   filter(date == transition_date) %>%
   pivot_longer(cols = -c(starts_with("mc_"), date), names_to = "geoid", values_to = "value") %>%
-  mutate(mc_variant_type = "OMICRON") %>%
+  mutate(mc_variant_type = opt$recode_variant) %>%
   group_by(across(c(-value))) %>%
   summarise(value = sum(value, na.rm = TRUE)) %>%  
   dplyr::mutate(mc_name = paste(mc_infection_stage, mc_vaccination_stage, mc_variant_type, mc_age_strata, sep = "_"))

--- a/preprocessing/seir_recode_omicron.R
+++ b/preprocessing/seir_recode_omicron.R
@@ -70,9 +70,6 @@ continued_seir <- arrow::read_parquet(opt$init_filename)
 head(continued_seir)
 unique(continued_seir$mc_variant_type)
 
-# seir file from continued run
-continued_seir <- arrow::read_parquet(opt$in_filename) 
-
 # subset at start date, smoosh all to Omicron
 seir_dt <- continued_seir %>% mutate(date = lubridate::as_date(date))  %>%
   select(-mc_name) %>%
@@ -90,12 +87,12 @@ seir_dt <- continued_seir %>% mutate(date = lubridate::as_date(date))  %>%
 ## Read in SEED files from resume, and remove other variants
 
 # seir file from continued run
-continued_seed <- readr::read_csv(opt$in_filename) 
+continued_seed <- readr::read_csv(opt$in_seed_filename) 
 
 # remove all but Omicron
 seed_dt <- continued_seed %>% mutate(date = lubridate::as_date(date))  %>%
-  filter(destination_variant_type == "OMICRON")
-
+  filter(destination_variant_type == "OMICRON") %>%
+  mutate(source_variant_type = "OMICRON")  
 
 
 # SAVE --------------------------------------------------------------------

--- a/preprocessing/seir_recode_omicron.R
+++ b/preprocessing/seir_recode_omicron.R
@@ -1,0 +1,93 @@
+##
+# @file
+# @brief Creates an init file converting all previous variants into Omicron 
+#
+# @details
+# ```
+
+# SETUP -------------------------------------------------------------------
+
+library(flepicommon)
+library(magrittr)
+library(dplyr)
+library(readr)
+library(tidyr)
+# library(purrr)
+
+select <- dplyr::select
+
+### ---> need to move whatever functions we need from this to flepicommon
+# install_configwriter <- FALSE
+#source("R/scripts/config_writers/config_writer_setup_flepimop.R")
+#####
+
+
+option_list <- list(
+  optparse::make_option(c("--res_config"), action = "store", default = Sys.getenv("RESUMED_CONFIG_PATH", NA), type = "character", help = "path to the previous config file"),
+  optparse::make_option(c("-c", "--config"), action = "store", default = Sys.getenv("CONFIG_PATH"), type = "character", help = "path to the config file"),
+  optparse::make_option(c("-p", "--flepi_path"), action="store", type='character', default = Sys.getenv("FLEPI_PATH", "flepiMoP/"), help="path to the flepiMoP directory"),
+  optparse::make_option(c("--in_filename"), action="store", type='character', default = Sys.getenv("IN_FILENAME"), help="seir file global intermediate name"), # This is the CONTINUED SEIR filename
+  optparse::make_option(c("--init_filename"), action="store", type='character', default = Sys.getenv("INIT_FILENAME"), help="init file global intermediate name") # This is the new init filename
+  )
+opt <- optparse::parse_args(optparse::OptionParser(option_list = option_list))
+
+print(paste0("Using config files: ", opt$config, " and ", opt$res_config))
+config <- flepicommon::load_config(opt$config)
+
+if (exists(config$initial_conditions$resumed_config)){
+  opt$res_config <- config$initial_conditions$resumed_config
+}
+
+res_config <- flepicommon::load_config(opt$res_config)
+
+if (length(config) == 0) {
+  stop("no configuration found -- please set CONFIG_PATH environment variable or use the -c command flag")
+}
+if (length(res_config) == 0) {
+  stop("no resumed configuration found -- please set RESUMED_CONFIG_PATH environment variable or use the -r command flag")
+}
+
+
+# INPUT -------------------------------------------------------------------
+
+# variant_compartments <- config$compartments$variant_type
+# age_strat <- config$compartments$age_strata
+
+compartment_tracts <- names(res_config$compartments)
+
+
+# PULL SEIR FILES -------------------------------------------------------------------
+## Read in SEIR files from resume, get the correct date and rewrite all variant types 
+
+# new config start date
+transition_date <- lubridate::as_date(config$start_date) 
+
+# seir file from continued run
+continued_seir <- arrow::read_parquet(opt$in_filename) 
+
+# subset at start date, smoosh all to Omicron
+seir_dt <- continued_seir %>% mutate(date = lubridate::as_date(date))  %>%
+  select(-mc_name) %>%
+  filter(mc_value_type == "prevalence") %>%
+  filter(date == transition_date) %>%
+  pivot_longer(cols = -c(starts_with("mc_"), date), names_to = "geoid", values_to = "value") %>%
+  mutate(mc_variant_type = "OMICRON") %>%
+  group_by(across(c(-value))) %>%
+  summarise(value = sum(value, na.rm = TRUE)) %>%  
+  dplyr::mutate(mc_name = paste(mc_infection_stage, mc_vaccination_stage, mc_variant_type, mc_age_strata, sep = "_"))
+  pivot_wider(names_from = geoid, values_from = value) 
+  
+
+
+# SAVE --------------------------------------------------------------------
+  
+# rewrite to new init file
+new_init_file <- opt$init_filename
+
+arrow::write_parquet(seir_dt, new_init_file)
+
+cat(paste0("\nWriting modified init file to: \n  -- ", new_init_file, "\n\n"))
+
+
+
+

--- a/preprocessing/seir_recode_omicron.R
+++ b/preprocessing/seir_recode_omicron.R
@@ -35,7 +35,7 @@ opt <- optparse::parse_args(optparse::OptionParser(option_list = option_list))
 print(paste0("Using config files: ", opt$config, " and ", opt$res_config))
 config <- flepicommon::load_config(opt$config)
 
-if (exists(config$initial_conditions$resumed_config)){
+if (!is.null(config$initial_conditions$resumed_config)){
   opt$res_config <- config$initial_conditions$resumed_config
 }
 

--- a/preprocessing/seir_recode_omicron.R
+++ b/preprocessing/seir_recode_omicron.R
@@ -26,7 +26,7 @@ option_list <- list(
   optparse::make_option(c("--res_config"), action = "store", default = Sys.getenv("RESUMED_CONFIG_PATH", NA), type = "character", help = "path to the previous config file"),
   optparse::make_option(c("-c", "--config"), action = "store", default = Sys.getenv("CONFIG_PATH"), type = "character", help = "path to the config file"),
   optparse::make_option(c("-p", "--flepi_path"), action="store", type='character', default = Sys.getenv("FLEPI_PATH", "flepiMoP/"), help="path to the flepiMoP directory"),
-  optparse::make_option(c("-v", "--recode_variant"), action="store", type='character', default = Sys.getenv("RECODE_VAR", "DELTA"), help="variant you want to change all variant_types to"),
+  optparse::make_option(c("-v", "--recode_variant"), action="store", type='character', default = Sys.getenv("RECODE_VAR", "BQ1"), help="variant you want to change all variant_types to"),
   optparse::make_option(c("--in_filename"), action="store", type='character', default = Sys.getenv("IN_FILENAME"), help="seir file global intermediate name"), # This is the CONTINUED SEIR filename
   optparse::make_option(c("--in_seed_filename"), action="store", type='character', default = Sys.getenv("IN_SEED_FILENAME"), help="seed file global intermediate name"), # This is the CONTINUED SEED filename
   optparse::make_option(c("--init_filename"), action="store", type='character', default = Sys.getenv("INIT_FILENAME"), help="init file global intermediate name") # This is the new init filename
@@ -77,7 +77,7 @@ seir_dt <- continued_seir %>% mutate(date = lubridate::as_date(date))  %>%
   filter(date == transition_date) %>%
   pivot_longer(cols = -c(starts_with("mc_"), date), names_to = "geoid", values_to = "value") %>%
   #mutate(mc_variant_type = opt$recode_variant) %>%
-  mutate(mc_variant_type = ifelse(mc_variant_type %in% c("WILD","ALPHA"),"DELTA",mc_variant_type)) %>% 
+  mutate(mc_variant_type = ifelse(mc_variant_type %in% c("WILD","ALPHA","DELTA","OMICRON","BA2","BA45"),"BQ1",mc_variant_type)) %>% 
   group_by(across(c(-value))) %>%
   summarise(value = sum(value, na.rm = TRUE)) %>%  
   dplyr::mutate(mc_name = paste(mc_infection_stage, mc_vaccination_stage, mc_variant_type, mc_age_strata, sep = "_")) %>%


### PR DESCRIPTION
Add preprocessing script that recodes all variants pre-Omicron to OMICRON. 

This recoding is for setting up a R17 phase 3 run with a variant structure (including BA2/2.12.1, BA4/BA5, BQ1, XBB) sub-lineages as separate variants. 

Reads in `seir` files from a resume and rewrites to the continued resume `init` files. 

Can recode into any variant by changing the flag `--recode-variant`. 