### PR TITLE
Address `FutureWarning` From `pandas.concat` In `gempyor`

### DIFF
--- a/flepimop/gempyor_pkg/src/gempyor/outcomes.py
+++ b/flepimop/gempyor_pkg/src/gempyor/outcomes.py
@@ -396,7 +396,7 @@ def compute_all_multioutcomes(
                         )
                     ),
                 }
-            ).set_index(pd.Index(2 * list(range(0, subpop_names_len))))
+            )
             hpar_list.append(hpar)
             # Now tackle NPI
             if npi is not None:


### PR DESCRIPTION
Small change to the `compute_all_multioutcomes` function to build the `hpar` data frame from a list in one call to `pandas.concat` rather than multiple sequential calls. The benefits are:

1. Addresses the `FutureWarning` in GH-244 by avoiding concatenation of an empty data frame.
2. This is slightly more performant, sequential repeated calls to `pandas.concat` can be expensive. Although since the outputs are relatively small this is a just a nice plus rather than a major benefit.

The explicit call to `set_index` is to replicate the old behavior, which is an index of something like 0, 1, ..., N, 0, 1, ..., N which came from concatenating 2 explicit data frames. I can remove that if we don't use this index anywhere, I'm just not familiar enough with the code OTOH to know right now. My guess would be we don't though.

Also, not 100% sure I requested the appropriate reviewers, if not please let me know.