### PR TITLE
`rolling_mean_pad` Performance Improvements

### DIFF
--- a/flepimop/gempyor_pkg/src/gempyor/utils.py
+++ b/flepimop/gempyor_pkg/src/gempyor/utils.py
@@ -7,6 +7,7 @@ import confuse
 import numpy as np
 import pandas as pd
 import pyarrow as pa
+import scipy.ndimage
 import scipy.stats
 import sympy.parsing.sympy_parser
 import subprocess
@@ -305,20 +306,19 @@ def rolling_mean_pad(data, window):
     Returns:
         A NumPy array with the padded rolling mean (n_days, nsubpops).
     """
-    padding_size = (window - 1) // 2
-    padded_data = np.pad(data, ((padding_size, padding_size), (0, 0)), mode="edge")
-
-    # Allocate space for the result
-    result = np.zeros_like(data)
-
-    # Perform convolution along the days axis (axis 0) using a loop
-    for i in range(data.shape[0]):
-        # Extract the current day's data from the padded array
-        window_data = padded_data[i : i + window, :]
-        # Calculate the rolling mean for this day's data
-        result[i, :] = np.mean(window_data, axis=0)
-
-    return result
+    weights = (1. / window) * np.ones(window)
+    output = scipy.ndimage.convolve1d(data, weights, axis=0, mode="nearest")
+    if window % 2 == 0:
+        rows, cols = data.shape
+        i = rows - 1
+        output[i, :] = 0.
+        window -= 1
+        weight = 1. / window
+        for l in range(-((window - 1) // 2), 1 + (window // 2)):
+            i_star = min(max(i + l, 0), i)
+            for j in range(cols):
+                output[i, j] += weight * data[i_star, j]
+    return output
 
 
 def print_disk_diagnosis():


### PR DESCRIPTION
Replaced custom rolling mean implementation using `np.pad` and `np.mean` with implementation based on `scipy.ndimage.convolve1d`. This implementation also maintains the window shrinking behavior of the current implementation by manually computing the last row.

Addresses GH-248, but there aren't any unit tests for `rolling_mean_pad` right now AFAICT so I would feel much more confident merging this in after GH-247 which adds unit tests for this function (and will probably generate some merge conflicts).