### PR TITLE
Fix: inference.py fails when no seir modifier config.

### DIFF
--- a/flepimop/gempyor_pkg/src/gempyor/inference.py
+++ b/flepimop/gempyor_pkg/src/gempyor/inference.py
@@ -538,10 +538,12 @@ class GempyorInference:
                 self.outcomes_parameters = outcomes.read_parameters_from_config(self.modinf)
 
             npi_outcomes = None
+            npi_seir = None
             if parallel:
                 with Timer("//things"):
                     with ProcessPoolExecutor(max_workers=max(mp.cpu_count(), 3)) as executor:
-                        ret_seir = executor.submit(seir.build_npi_SEIR, self.modinf, load_ID, sim_id2load, config)
+                        if self.modinf.seir_config is not None and self.modinf.npi_config_seir is not None:
+                            ret_seir = executor.submit(seir.build_npi_SEIR, self.modinf, load_ID, sim_id2load, config)
                         if self.modinf.outcomes_config is not None and self.modinf.npi_config_outcomes:
                             ret_outcomes = executor.submit(
                                 outcomes.build_outcome_modifiers,
@@ -563,15 +565,17 @@ class GempyorInference:
                         self.proportion_info,
                     ) = ret_comparments.result()
                     self.already_built = True
-                npi_seir = ret_seir.result()
+                if self.modinf.seir_config is not None and self.modinf.npi_config_seir is not None:
+                    npi_seir = ret_seir.result()
                 if self.modinf.outcomes_config is not None and self.modinf.npi_config_outcomes:
                     npi_outcomes = ret_outcomes.result()
             else:
                 if not self.already_built:
                     self.build_structure()
-                npi_seir = seir.build_npi_SEIR(
-                    modinf=self.modinf, load_ID=load_ID, sim_id2load=sim_id2load, config=config
-                )
+                if self.modinf.seir_config is not None and self.modinf.npi_config_seir is not None:
+                    npi_seir = seir.build_npi_SEIR(
+                        modinf=self.modinf, load_ID=load_ID, sim_id2load=sim_id2load, config=config
+                    )
                 if self.modinf.outcomes_config is not None and self.modinf.npi_config_outcomes:
                     npi_outcomes = outcomes.build_outcome_modifiers(
                         modinf=self.modinf,

--- a/flepimop/gempyor_pkg/src/gempyor/steps_rk4.py
+++ b/flepimop/gempyor_pkg/src/gempyor/steps_rk4.py
@@ -134,7 +134,7 @@ def rk4_integration(
                         rate_change_compartment *= parameters[transitions[transition_rate_col][transition_index]][
                             today
                         ][visiting_subpop]
-                        total_rate[spatial_node] *= rate_keep_compartment + rate_change_compartment.sum()
+                        total_rate[spatial_node] *= (rate_keep_compartment + rate_change_compartment.sum())
 
             # compute the number of individual transitioning from source to destination from the total rate
             # number_move has shape (nspatial_nodes)

--- a/flepimop/gempyor_pkg/tests/inference/data/config_inference_without_seir_modifiers.yml
+++ b/flepimop/gempyor_pkg/tests/inference/data/config_inference_without_seir_modifiers.yml
@@ -1,0 +1,67 @@
+name: minimal_test
+setup_name: minimal_test_setup
+start_date: 2020-01-31
+end_date: 2020-05-31
+nslots: 5
+
+subpop_setup:
+  geodata: data/geodata.csv
+  mobility: data/mobility.csv
+
+initial_conditions:
+  method: Default
+
+compartments:
+  infection_stage: ["S", "E", "I1", "I2", "I3", "R"]
+  vaccination_stage: ["unvaccinated"]
+
+seir:
+  integration:
+    method: legacy
+    dt: 1/6
+  parameters:
+    alpha:
+      value: .9
+    sigma:
+      value:
+        distribution: fixed
+        value: 1 / 5.2
+    gamma:
+      value:
+        distribution: uniform
+        low: 1 / 6
+        high: 1 / 2.6
+    R0s:
+      value:
+        distribution: uniform
+        low: 2
+        high: 3
+  transitions:
+    - source: ["S", "unvaccinated"]
+      destination: ["E", "unvaccinated"]
+      rate: ["R0s * gamma", 1]
+      proportional_to: [
+          ["S", "unvaccinated"],
+          [[["I1", "I2", "I3"]], "unvaccinated"],
+      ]
+      proportion_exponent: [["1", "1"], ["alpha", "1"]] 
+    - source: [["E"], ["unvaccinated"]]
+      destination: [["I1"], ["unvaccinated"]]
+      rate: ["sigma", 1]
+      proportional_to: [[["E"], ["unvaccinated"]]]
+      proportion_exponent: [["1", "1"]]
+    - source: [["I1"], ["unvaccinated"]]
+      destination: [["I2"], ["unvaccinated"]]
+      rate: ["3 * gamma", 1]
+      proportional_to: [[["I1"], ["unvaccinated"]]]
+      proportion_exponent: [["1", "1"]]
+    - source: [["I2"], ["unvaccinated"]]
+      destination: [["I3"], ["unvaccinated"]]
+      rate: ["3 * gamma", 1]
+      proportional_to: [[["I2"], ["unvaccinated"]]]
+      proportion_exponent: [["1", "1"]]
+    - source: [["I3"], ["unvaccinated"]]
+      destination: [["R"], ["unvaccinated"]]
+      rate: ["3 * gamma", 1]
+      proportional_to: [[["I3"], ["unvaccinated"]]]
+      proportion_exponent: [["1", "1"]]

--- a/flepimop/gempyor_pkg/tests/inference/test_inference.py
+++ b/flepimop/gempyor_pkg/tests/inference/test_inference.py
@@ -64,3 +64,15 @@ class TestGempyorInference:
 
         i.already_built = False
         i.one_simulation(sim_id2write=0, parallel=True)
+
+    # HopkinsIDD/flepiMoP#269
+    def test_inference_without_seir_modifiers(self):
+        # Setup
+        os.chdir(os.path.dirname(__file__))
+        gempyor_inference = inference.GempyorInference(
+            f"{DATA_DIR}/config_inference_without_seir_modifiers.yml",
+        )
+
+        # Test
+        simulation_int = gempyor_inference.one_simulation(0)
+        assert simulation_int == 0


### PR DESCRIPTION
inference.py did not make use of the flag from modinf about the existence of a seir modifier config, so it failed if there was no seir modifier config.

This makes it hard to test #266 with my usual notebook that builds a gempyor object.

Also adding some parenthesis. Ideally we will want step_rk4 to be much more explicit.