### PR TITLE
Make `test_get_run_id_default_timestamp` Test Fixture More Robust

### DIFF
--- a/flepimop/gempyor_pkg/tests/file_paths/test_run_id.py
+++ b/flepimop/gempyor_pkg/tests/file_paths/test_run_id.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 import re
 
 import pytest
@@ -23,7 +23,7 @@ class TestRunId:
 
         # Run id is between before/after
         before = before.replace(microsecond=0)
-        after = after.replace(microsecond=0, second=after.second + 1)
+        after = (after + timedelta(seconds=1)).replace(microsecond=0)
         run_time = datetime.strptime(rid, "%Y%m%d_%H%M%S")
         assert run_time >= before
         assert run_time <= after


### PR DESCRIPTION
**Describe your changes.**

Use a `timedelta` object to handle adding a second to the after timestamp instead of manually adding 1 second to avoid issues with the 59th second.

**What does your pull request address? Tag relevant issues.**

GH-287

**Mentions of relevant team members.**

@saraloo, @emprzy 