### PR TITLE
modified to capture stdout and stderr to log in using system2() being…

### DIFF
--- a/flepimop/R_packages/inference/inst/scripts/flepimop-inference-main.R
+++ b/flepimop/R_packages/inference/inst/scripts/flepimop-inference-main.R
@@ -125,16 +125,9 @@ foreach(seir_modifiers_scenario = seir_modifiers_scenarios) %:%
       ground_truth_end_text <- c("--ground_truth_end", opt$ground_truth_end)
     }
 
-    log_file <- file.path(
-        "model_output",
-        config$name,
-        opt$run_id,
-        "log",
-        paste0("log_inference_slot", flepi_slot, ".txt")
+    log_file <- paste0(
+        "log_inference_slot_", config$name, "_", opt$run_id, "_", flepi_slot, ".txt"
     )
-    if (!dir.exists(dirname(log_file))) {
-      dir.create(dirname(log_file), recursive = TRUE, showWarnings = TRUE)
-    }
     command <- c(
         file.path(opt$flepi_path, "flepimop", "main_scripts","inference_slot.R"),
         "-c", opt$config,

--- a/flepimop/R_packages/inference/inst/scripts/flepimop-inference-main.R
+++ b/flepimop/R_packages/inference/inst/scripts/flepimop-inference-main.R
@@ -124,14 +124,18 @@ foreach(seir_modifiers_scenario = seir_modifiers_scenarios) %:%
     if (nchar(opt$ground_truth_end) > 0) {
       ground_truth_end_text <- c("--ground_truth_end", opt$ground_truth_end)
     }
-    #log_file <- paste0("log_inference_slot_", config$name, "_", opt$run_id, "_", flepi_slot, ".txt")
-    log_file2 <- paste0("model_output/", config$name, "/", opt$run_id, "/log/log_inference_slot_", flepi_slot, ".txt")
 
-    if (!dir.exists(dirname(log_file2))) {
-      dir.create(dirname(log_file2), recursive = TRUE, showWarnings = TRUE)
+    log_file <- file.path(
+        "model_output",
+        config$name,
+        opt$run_id,
+        "log",
+        paste0("log_inference_slot", flepi_slot, ".txt")
+    )
+    if (!dir.exists(dirname(log_file))) {
+      dir.create(dirname(log_file), recursive = TRUE, showWarnings = TRUE)
     }
     command <- c(
-        # opt$rpath,
         file.path(opt$flepi_path, "flepimop", "main_scripts","inference_slot.R"),
         "-c", opt$config,
         "-u", opt$run_id,
@@ -155,14 +159,15 @@ foreach(seir_modifiers_scenario = seir_modifiers_scenarios) %:%
         "-M", opt$memory_profiling,
         "-P", opt$memory_profiling_iters,
         "-g", opt$subpop_len,
-        #paste("2>&1 | tee log_inference_slot_",config$name,"_",opt$run_id, "_", flepi_slot, ".txt", sep=""), # works on Mac only, not windows
-        #paste("2>&1 | tee model_output/",config$name,"/",opt$run_id,"/log/log_inference_slot", flepi_slot, ".txt", sep=""), # doesn't work because config$name needs to be combined with scenarios to generate the folder name, and, because this command seems to only be able to pipe output to pre-existing folders
-        sep = " ")
+        sep = " "
+    )
     err <- tryCatch({
-        system2(command = opt$rpath, args = command, stdout = log_file2, stderr = log_file2)
+        system2(
+            command = opt$rpath, args = command, stdout = log_file, stderr = log_file
+        )
     }, error = function(e) {
         message <- paste("Error in slot", flepi_slot, ":", e$message)
-        writeLines(message, con = log_file2)
+        writeLines(message, con = log_file)
         return(1)  # Return non-zero to indicate error
     })
     if(err != 0){quit("no")}

--- a/flepimop/R_packages/inference/inst/scripts/flepimop-inference-main.R
+++ b/flepimop/R_packages/inference/inst/scripts/flepimop-inference-main.R
@@ -128,8 +128,14 @@ foreach(seir_modifiers_scenario = seir_modifiers_scenarios) %:%
     log_file <- paste0(
         "log_inference_slot_", config$name, "_", opt$run_id, "_", flepi_slot, ".txt"
     )
+    inference_slot_cmd <- unname(Sys.which("flepimop-inference-slot"))
+    if (inference_slot_cmd == "") {
+        stop(
+          "`flepimop-inference-slot` not found in PATH, unable to run inference slot"
+        )
+    }
     command <- c(
-        file.path(opt$flepi_path, "flepimop", "main_scripts","inference_slot.R"),
+        inference_slot_cmd,
         "-c", opt$config,
         "-u", opt$run_id,
         "-s", opt$seir_modifiers_scenarios,


### PR DESCRIPTION
… applicable in Windows as well in flepimop/main_scripts/inference_main.R

**Describe your changes.**

- use system2() in place of system(), with dir precheck to capture msgs on both stdout and stdout  
- modified (assumed) to run in Windows as well
  - Checked okay on WSL2-Windows(ubuntu) of course 
- use 'tryCatch' 

**What does your pull request address? Tag relevant issues.**
https://github.com/HopkinsIDD/flepiMoP/issues/169
**Mentions of relevant team members.**
Please check out whether it works if possible @kimberlynroosa @saraloo 