### PR TITLE
Correcting issue labels in `bug_report.yml` and `feature_request.yml`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,8 +18,6 @@ body:
         - docstring
         - duplicate
         - enhancement
-        - flepicommon
-        - flepiconfig
         - gempyor
         - good first issue
         - inference
@@ -30,6 +28,9 @@ body:
         - plotting
         - post-processing
         - quick issue
+        - r-flepicommon
+        - r-flepiconfig
+        - r-inference
         - seeding
         - submission
         - wontfix

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -13,11 +13,13 @@ body:
         - bug
         - batch
         - config
-        - flepiconfig
+        - dependency
         - documentation
         - docstring
         - duplicate
         - enhancement
+        - flepicommon
+        - flepiconfig
         - gempyor
         - good first issue
         - inference
@@ -25,6 +27,7 @@ body:
         - meta/workflow
         - operations
         - performance
+        - plotting
         - post-processing
         - quick issue
         - seeding

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -18,8 +18,6 @@ body:
         - docstring
         - duplicate
         - enhancement
-        - flepicommon
-        - flepiconfig
         - gempyor
         - good first issue
         - inference
@@ -30,6 +28,9 @@ body:
         - plotting
         - post-processing
         - quick issue
+        - r-flepicommon
+        - r-flepiconfig
+        - r-inference
         - seeding
         - submission
         - wontfix

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -13,11 +13,13 @@ body:
         - bug
         - batch
         - config
-        - flepiconfig
+        - dependency
         - documentation
         - docstring
         - duplicate
         - enhancement
+        - flepicommon
+        - flepiconfig
         - gempyor
         - good first issue
         - inference
@@ -25,6 +27,7 @@ body:
         - meta/workflow
         - operations
         - performance
+        - plotting
         - post-processing
         - quick issue
         - seeding


### PR DESCRIPTION
### Describe your changes.
**!! Sorry, this is essentially a duplicate of the first PR (GH #381) I re-named the branch at the head of that PR and did not realize it would close the PR !!** 
This pull request adjusts the labels associated with the R packages (`r-flepiconfig`, `r-flepicommon`, `r-inference`). The `r-` prefix was added to show specificity to the R framework (note that `inference` and `r-inference` are two distinct labels). 
I will also reiterate that the accidentally-deleted PR before this added `dependency` and `plotting` labels. 


### What does your pull request address? Tag relevant issues.
This pull request addresses GH #319 , and conversation beneath it. 
