### PR TITLE
Deactivate Conda Env In HPC Init Script

### DIFF
--- a/batch/hpc_init.sh
+++ b/batch/hpc_init.sh
@@ -52,7 +52,14 @@ if [ -z "${FLEPI_CONDA}" ]; then
     fi
     echo "Using '$FLEPI_CONDA' for \$FLEPI_CONDA."
 fi
-conda activate $FLEPI_CONDA
+CURRENT_CONDA_ENV=$( conda info | grep "active environment" | awk -F ':' '{print $2}' | xargs )
+if [ "$CURRENT_CONDA_ENV" != "None" ] && [ "$CURRENT_CONDA_ENV" != "$FLEPI_CONDA" ]; then
+    echo "Detected an active conda environment '$CURRENT_CONDA_ENV'. This will be deactivated and the '$FLEPI_CONDA' environment will be activated."
+    conda deactivate
+fi
+if [ "$CURRENT_CONDA_ENV" == "None" ] || [ "$CURRENT_CONDA_ENV" != "$FLEPI_CONDA" ]; then
+    conda activate $FLEPI_CONDA
+fi
 
 # Check the conda environment is valid
 WHICH_PYTHON=$( which python )

--- a/batch/hpc_init.sh
+++ b/batch/hpc_init.sh
@@ -53,13 +53,14 @@ if [ -z "${FLEPI_CONDA}" ]; then
     echo "Using '$FLEPI_CONDA' for \$FLEPI_CONDA."
 fi
 CURRENT_CONDA_ENV=$( conda info | grep "active environment" | awk -F ':' '{print $2}' | xargs )
-if [ "$CURRENT_CONDA_ENV" != "None" ] && [ "$CURRENT_CONDA_ENV" != "$FLEPI_CONDA" ]; then
-    echo "Detected an active conda environment '$CURRENT_CONDA_ENV'. This will be deactivated and the '$FLEPI_CONDA' environment will be activated."
+if [ "$CURRENT_CONDA_ENV" = "$FLEPI_CONDA" ]; then
+    echo "Detected the activate conda environment is '$FLEPI_CONDA' already, but will refresh."
+    conda deactivate
+elif [ "$CURRENT_CONDA_ENV" != "None" ]; then
+    echo "Detected an active conda environment '$CURRENT_CONDA_ENV'. This will be deactivated and the '$FLEPI_CONDA' environment wil be activated."
     conda deactivate
 fi
-if [ "$CURRENT_CONDA_ENV" == "None" ] || [ "$CURRENT_CONDA_ENV" != "$FLEPI_CONDA" ]; then
-    conda activate $FLEPI_CONDA
-fi
+conda activate $FLEPI_CONDA
 
 # Check the conda environment is valid
 WHICH_PYTHON=$( which python )


### PR DESCRIPTION
### Describe your changes.

This is to address a bug where a currently active env would cause the HPC init script to uncleanly load the flepiMoP env. Simplest solution is to always deactivate before activating. Redundant in the case that the flepiMoP env is already active, but easier than trying to determine the current env. No downside if no env is active.

### What does your pull request address? Tag relevant issues.

No issue to tag, just noticed this issue while working on GH-365. Before this change (notice the `flepimop-env` is active):
```bash
(flepimop-env) [twillard@longleaf-login1 flepiMoP]$ source batch/hpc_init.sh longleaf
An explicit $FLEPI_PATH was not provided, please set one (or press enter to use '/work/users/t/w/twillard/flepiMoP'):
Using '/work/users/t/w/twillard/flepiMoP' for $FLEPI_PATH.
An explicit $FLEPI_CONDA was not provided, please set one (or press enter to use 'flepimop-env'):
Using 'flepimop-env' for $FLEPI_CONDA.
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ModuleNotFoundError: No module named 'pyarrow'
Connection to longleaf.unc.edu closed.
```
and after:
```bash
(flepimop-env) [twillard@longleaf-login6 flepiMoP]$ source batch/hpc_init.sh longleaf
An explicit $FLEPI_PATH was not provided, please set one (or press enter to use '/work/users/t/w/twillard/flepiMoP'):
Using '/work/users/t/w/twillard/flepiMoP' for $FLEPI_PATH.
An explicit $FLEPI_CONDA was not provided, please set one (or press enter to use 'flepimop-env'):
Using 'flepimop-env' for $FLEPI_CONDA.
Please set a project path (relative to '/work/users/t/w/twillard'):
...
```

### Tag relevant team members.

@anjalika-nande, @emprzy, @fang19911030, @jcblemai, @pearsonca, @saraloo


