### PR TITLE
Emcee batch fix

### DIFF
--- a/flepimop/gempyor_pkg/src/gempyor/calibrate.py
+++ b/flepimop/gempyor_pkg/src/gempyor/calibrate.py
@@ -171,6 +171,8 @@ def calibrate(
 
     # Draw/get initial parameters:
     backend = emcee.backends.HDFBackend(filename)
+    # save the dataframe of parameter names (this should be added to the h5 file)
+    gempyor_inference.inferpar.get_parameter_df().to_csv(filename.replace(".h5", ".csv"), index=True)
     if resume or resume_location is not None:
         # Normally one would put p0 = None to get the last State from the sampler, but that poses problems when the likelihood change
         # and then acceptances are not guaranted, see issue #316. This solves this issue and greates a new chain with llik evaluation

--- a/flepimop/gempyor_pkg/src/gempyor/inference.py
+++ b/flepimop/gempyor_pkg/src/gempyor/inference.py
@@ -382,14 +382,15 @@ class GempyorInference:
         self.already_built = False  # whether we have already built the costly objects that need just one build
         self.autowrite_seir = autowrite_seir
 
-        self.static_sim_arguments = get_static_arguments(self.modinf)
-
         ## Inference Stuff
         self.do_inference = False
         if config["inference"].exists():
             from . import inference_parameter, logloss
 
             if config["inference"]["method"].get("default") == "emcee":
+                # Generates the static_sim_arguments only if this is a config argument.
+                self.static_sim_arguments = get_static_arguments(self.modinf)
+                
                 self.do_inference = True
                 self.inference_method = "emcee"
                 self.inferpar = inference_parameter.InferenceParameters(

--- a/flepimop/gempyor_pkg/src/gempyor/inference_parameter.py
+++ b/flepimop/gempyor_pkg/src/gempyor/inference_parameter.py
@@ -245,7 +245,7 @@ class InferenceParameters:
 
         # Ideally this should lie in each submodules, e.g NPI.inject, parameter.inject
         if self.get_dim() != len(proposal):
-            raise ValueError(f"Inference object stores {self.get_dim()} parameters, but received a proposal of lenght {len(proposal)} to be injected.")
+            raise ValueError(f"Inference object stores {self.get_dim()} parameters, but received a proposal of length {len(proposal)} to be injected.")
 
         for p_idx in range(self.get_dim()):
             if self.ptypes[p_idx] == "seir_modifiers":

--- a/flepimop/gempyor_pkg/src/gempyor/inference_parameter.py
+++ b/flepimop/gempyor_pkg/src/gempyor/inference_parameter.py
@@ -175,17 +175,13 @@ class InferenceParameters:
         return len(self.pnames)
     
     def get_parameter_df(self):
-        all_params = []
-
-        for i in zip(self.ptypes, self.subpops,self.pnames):
-            data = {
-                "ptypes": self.ptypes,
-                "subpops": self.subpops,
-                "pnames": self.pnames
-            }
-            all_params.append(pd.DataFrame(data))
-
-        return pd.concat(all_params)
+        data = {
+            "ptypes": self.ptypes,
+            "subpops": self.subpops,
+            "pnames": self.pnames
+        }
+        df = pd.DataFrame(data)
+        return df
 
     def draw_initial(self, n_draw=1):
         """

--- a/flepimop/gempyor_pkg/src/gempyor/inference_parameter.py
+++ b/flepimop/gempyor_pkg/src/gempyor/inference_parameter.py
@@ -173,6 +173,19 @@ class InferenceParameters:
         so one can use the built-in python len function
         """
         return len(self.pnames)
+    
+    def get_parameter_df(self):
+        all_params = []
+
+        for i in zip(self.ptypes, self.subpops,self.pnames):
+            data = {
+                "ptypes": self.ptypes,
+                "subpops": self.subpops,
+                "pnames": self.pnames
+            }
+            all_params.append(pd.DataFrame(data))
+
+        return pd.concat(all_params)
 
     def draw_initial(self, n_draw=1):
         """

--- a/flepimop/gempyor_pkg/src/gempyor/inference_parameter.py
+++ b/flepimop/gempyor_pkg/src/gempyor/inference_parameter.py
@@ -244,6 +244,8 @@ class InferenceParameters:
         hnpi_df_mod = hnpi_df.copy(deep=True)
 
         # Ideally this should lie in each submodules, e.g NPI.inject, parameter.inject
+        if self.get_dim() != len(proposal):
+            raise ValueError(f"Inference object stores {self.get_dim()} parameters, but received a proposal of lenght {len(proposal)} to be injected.")
 
         for p_idx in range(self.get_dim()):
             if self.ptypes[p_idx] == "seir_modifiers":

--- a/flepimop/gempyor_pkg/src/gempyor/outcomes.py
+++ b/flepimop/gempyor_pkg/src/gempyor/outcomes.py
@@ -198,6 +198,8 @@ def read_parameters_from_config(modinf: model_info.ModelInfo):
                         parameters[new_comp]["delay::npi_param_name"] = f"{new_comp}::delay".lower()
                 else:
                     logging.critical(f"No delay for outcome {new_comp}, using a 0 delay")
+                    # FIXME: We should not here modify outcomes_config := modinf.outcomes_config["outcomes"]
+                    # because this changes the order in which the outcomes the next time this function is called.
                     outcomes_config[new_comp]["delay"] = {"value": 0}
                     parameters[new_comp]["delay"] = outcomes_config[new_comp]["delay"]["value"]
                     parameters[new_comp]["delay::npi_param_name"] = f"{new_comp}::delay".lower()


### PR DESCRIPTION
### Describe your changes.

This adds two things to emcee_batch:
1. `flepimop-calibrate` now saves a .csv file named the same name as the h5 file containing the parameter's names and their order. This would have been very helpful to Josh and would have made storing our run easier. Obviously, this is a bad way to do it, we would want the axes to be parameter names, and these files (h5, csv) to be in a /chain/ folder or something and all. Roughly tested that this work on RSV and Flu
2. Fix #373 badly: not the underlying cause (added a #FIXME there) but we just create emcee static arguments if the configs call for emcee inference. This is good anyway (and the way it was done before but then to facilitate notebook access it was created at each time).

### Tag relevant team members.

@saraloo your RSV will work with this PR
@pearsonca @TimothyWillard I let you see if you want to include that in this release cycle/hold off/address the main cause before.
