### PR TITLE
Remove Dead Methods From `gempyor.parameters.Parameters`

### DIFF
--- a/flepimop/gempyor_pkg/src/gempyor/parameters.py
+++ b/flepimop/gempyor_pkg/src/gempyor/parameters.py
@@ -84,7 +84,8 @@ class Parameters:
         self.npar = len(self.pnames)
         if self.npar != len(set([name.lower() for name in self.pnames])):
             raise ValueError(
-                "Parameters of the SEIR model have the same name (remember that case is not sufficient!)"
+                "Parameters of the SEIR model have the same "
+                "name (remember that case is not sufficient!)"
             )
 
         # Attributes of dictionary
@@ -128,16 +129,18 @@ class Parameters:
                     print("loaded dates:", df.index)
                     raise ValueError(
                         f"Issue loading file '{fn_name}' for parameter '{pn}': "
-                        f"Provided file dates span '{str(df.index[0])}' to '{str(df.index[-1])}', "
-                        f"but the config dates span '{ti}' to '{tf}'."
+                        f"Provided file dates span '{str(df.index[0])}' to "
+                        f"'{str(df.index[-1])}', but the config dates "
+                        f"span '{ti}' to '{tf}'."
                     )
                 if not (pd.date_range(ti, tf) == df.index).all():
                     print("config dates:", pd.date_range(ti, tf))
                     print("loaded dates:", df.index)
                     raise ValueError(
                         f"Issue loading file '{fn_name}' for parameter '{pn}': "
-                        f"Provided file dates span '{str(df.index[0])}' to '{str(df.index[-1])}', "
-                        f"but the config dates span '{ti}' to '{tf}'."
+                        f"Provided file dates span '{str(df.index[0])}' to "
+                        f"'{str(df.index[-1])}', but the config dates "
+                        f"span '{ti}' to '{tf}'."
                     )
 
                 self.pdata[pn]["ts"] = df
@@ -148,7 +151,8 @@ class Parameters:
             else:
                 self.pdata[pn]["stacked_modifier_method"] = "product"
                 logging.debug(
-                    f"No 'stacked_modifier_method' for parameter {pn}, assuming multiplicative NPIs"
+                    f"No 'stacked_modifier_method' for parameter {pn}, "
+                    "assuming multiplicative NPIs."
                 )
 
             if self.pconfig[pn]["rolling_mean_windows"].exists():
@@ -209,7 +213,8 @@ class Parameters:
             else:
                 param_arr[idx] = self.pdata[pn]["ts"].values
 
-        return param_arr  # we don't store it as a member because this object needs to be small to be pickable
+        # we don't store it as a member because this object needs to be small to be pickable
+        return param_arr
 
     def parameters_load(
         self, param_df: pd.DataFrame, n_days: int, nsubpops: int
@@ -249,7 +254,8 @@ class Parameters:
                 param_arr[idx] = self.pdata[pn]["ts"].values
             else:
                 print(
-                    f"PARAM: parameter {pn} NOT found in loadID file. Drawing from config distribution"
+                    f"PARAM: parameter {pn} NOT found in loadID file. "
+                    "Drawing from config distribution"
                 )
                 pval = self.pdata[pn]["dist"]()
                 param_arr[idx] = np.full((n_days, nsubpops), pval)

--- a/flepimop/gempyor_pkg/src/gempyor/parameters.py
+++ b/flepimop/gempyor_pkg/src/gempyor/parameters.py
@@ -165,32 +165,6 @@ class Parameters:
         logging.debug(f"Index in arrays are: {self.pnames2pindex}")
         logging.debug(f"NPI overlap operation is {self.stacked_modifier_method} ")
 
-    def picklable_lamda_alpha(self):
-        """
-        Read the `alpha_val` attribute.
-
-        This defunct method returns the `alpha_val` attribute of this class which is
-        never set by this class. If this method is called and the `alpha_val` attribute
-        is not set an AttributeError will be raised.
-
-        Returns:
-            The `alpha_val` attribute.
-        """
-        return self.alpha_val
-
-    def picklable_lamda_sigma(self):
-        """
-        Read the `sigma_val` attribute.
-
-        This defunct method returns the `sigma_val` attribute of this class which is
-        never set by this class. If this method is called and the `sigma_val` attribute
-        is not set an AttributeError will be raised.
-
-        Returns:
-            The `sigma_val` attribute.
-        """
-        return self.sigma_val
-
     def get_pnames2pindex(self) -> dict:
         """
         Read the `pnames2pindex` attribute.

--- a/flepimop/gempyor_pkg/tests/parameters/test_parameters_class.py
+++ b/flepimop/gempyor_pkg/tests/parameters/test_parameters_class.py
@@ -237,7 +237,8 @@ class TestParameters:
             ValueError,
             match=(
                 rf"^Issue loading file '{tmp_file}' for parameter 'sigma': "
-                rf"the number of non-'date' columns is '{actual_columns}', expected '{mock_inputs.number_of_subpops()}' "
+                rf"the number of non-'date' columns is '{actual_columns}', expected "
+                rf"'{mock_inputs.number_of_subpops()}' "
                 rf"\(number of subpopulations\) or one\.$"
             ),
         ):
@@ -282,7 +283,8 @@ class TestParameters:
             ValueError,
             match=(
                 f"Issue loading file '{tmp_file}' for parameter 'sigma': "
-                f"Provided file dates span '{timeseries_start_date}( 00:00:00)?' to '{timeseries_end_date}( 00:00:00)?', "
+                f"Provided file dates span '{timeseries_start_date}( 00:00:00)?' to "
+                rf"'{timeseries_end_date}( 00:00:00)?', "
                 f"but the config dates span '{mock_inputs.ti}' to '{mock_inputs.tf}'.$"
             ),
         ):

--- a/flepimop/gempyor_pkg/tests/parameters/test_parameters_class.py
+++ b/flepimop/gempyor_pkg/tests/parameters/test_parameters_class.py
@@ -8,7 +8,6 @@ import confuse
 import numpy as np
 import pandas as pd
 import pytest
-from tempfile import NamedTemporaryFile
 
 from gempyor.parameters import Parameters
 from gempyor.testing import (
@@ -373,58 +372,6 @@ class TestParameters:
             modifier_type = param_conf.get("stacked_modifier_method", "product")
             expected_stacked_modifier_method[modifier_type].append(param_name.lower())
         assert params.stacked_modifier_method == expected_stacked_modifier_method
-
-    @pytest.mark.parametrize(
-        "factory,alpha_val",
-        [
-            (fixed_three_valid_parameter_factory, None),
-            (fixed_three_valid_parameter_factory, 123),
-            (valid_parameters_factory, "abc"),
-        ],
-    )
-    def test_picklable_lamda_alpha(
-        self,
-        tmp_path: pathlib.Path,
-        factory: Callable[[pathlib.Path], MockParametersInput],
-        alpha_val: Any,
-    ) -> None:
-        # Setup
-        mock_inputs = factory(tmp_path)
-        params = mock_inputs.create_parameters_instance()
-
-        # Attribute error if `alpha_val` is not set
-        with pytest.raises(AttributeError):
-            params.picklable_lamda_alpha()
-
-        # We get the expected value when `alpha_val` is set
-        params.alpha_val = alpha_val
-        assert params.picklable_lamda_alpha() == alpha_val
-
-    @pytest.mark.parametrize(
-        "factory,sigma_val",
-        [
-            (fixed_three_valid_parameter_factory, None),
-            (fixed_three_valid_parameter_factory, 123),
-            (valid_parameters_factory, "abc"),
-        ],
-    )
-    def test_picklable_lamda_sigma(
-        self,
-        tmp_path: pathlib.Path,
-        factory: Callable[[pathlib.Path], MockParametersInput],
-        sigma_val: Any,
-    ) -> None:
-        # Setup
-        mock_inputs = factory(tmp_path)
-        params = mock_inputs.create_parameters_instance()
-
-        # Attribute error if `sigma_val` is not set
-        with pytest.raises(AttributeError):
-            params.picklable_lamda_sigma()
-
-        # We get the expected value when `sigma_val` is set
-        params.sigma_val = sigma_val
-        assert params.picklable_lamda_sigma() == sigma_val
 
     @pytest.mark.parametrize(
         "factory",


### PR DESCRIPTION
### Describe your changes.

This PR removes the `picklable_lamda_alpha/sigma` methods from the `Parameters` class. These methods are not used anywhere in the `flepiMoP` codebase.

### Does this pull request make any user interface changes? If so please describe.

Yes this removes two methods that were previously publicly accessible.

### What does your pull request address? Tag relevant issues.

This pull request helps to address GH-276.