### PR TITLE
User local installation documentation and bash script

### DIFF
--- a/build/local_install_or_update.sh
+++ b/build/local_install_or_update.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Generic setup
+set -e
+
+# Ensure we have a $FLEPI_PATH
+if [ -z "${FLEPI_PATH}" ]; then
+    export USERDIR=$(pwd)
+    export FLEPI_PATH="$USERDIR/flepiMoP"
+    export FLEPI_PATH=$( realpath "$FLEPI_PATH" )
+    echo "Using '$FLEPI_PATH' for \$FLEPI_PATH."
+fi
+
+# Test that flepiMoP is located there, exit if not
+if [ ! -d "$FLEPI_PATH" ]; then
+    echo "Could not find flepiMoP repository in your directory. Please make sure you have correctly cloned flepiMoP in this directory."
+    exit 1
+fi
+
+# Ensure that conda environment is named flepimop-env
+if [ -z "${FLEPI_CONDA}" ]; then
+    export FLEPI_CONDA="flepimop-env"
+    echo "Using '$FLEPI_CONDA' for \$FLEPI_CONDA."
+fi
+
+# Check that the name of the FLEPI_CONDA variable matches the environment that has been set up, exit if not
+FLEPI_CONDA_ENV_MATCHES=$( conda info --envs | awk '{print $1}' | grep -x "$FLEPI_CONDA" | wc -l )
+if [ "$FLEPI_CONDA_ENV_MATCHES" -eq 0 ]; then
+    echo "Issue with conda environment: ensure you have set up your conda environment and it has the correct name."
+    exit 1
+fi
+
+# Load the conda environment
+conda activate $FLEPI_CONDA
+[ -e "$CONDA_PREFIX/conda-meta/pinned" ] && rm $CONDA_PREFIX/conda-meta/pinned
+cat << EOF > $CONDA_PREFIX/conda-meta/pinned
+r-arrow==17.0.0
+arrow==17.0.0
+EOF
+
+# Install the gempyor package from local
+pip install --editable $FLEPI_PATH/flepimop/gempyor_pkg
+
+# Install the local R packages
+R -e "install.packages('covidcast', repos='https://cloud.r-project.org')"
+RETURNTO=$( pwd )
+cd $FLEPI_PATH/flepimop/R_packages/
+for d in $( ls ); do
+    R CMD INSTALL $d
+done
+cd $RETURNTO
+R -e "library(inference); inference::install_cli()"
+
+# Done
+echo "> Done installing/updating flepiMoP."
+set +e
+
+
+

--- a/documentation/gitbook/how-to-run/local-installation.md
+++ b/documentation/gitbook/how-to-run/local-installation.md
@@ -1,0 +1,58 @@
+---
+description: >-
+    Instructions on how to proceed with the installations necessary for local flepiMoP use.
+---
+
+
+# Local flepiMoP installation
+
+## ⇅ Get set up to use Github
+
+You need to interact with Github to run and edit `flepiMoP` code. [Github](https://github.com/) is a web platform for people to share and manage software, and it is based on a 'version control' software called `git` that helps programmers keep track of changes to code. Flepimop core code as well as example projects using flepimop code are all stored on Github, and frequently being updated. The first step to using flepimop for your own project is making sure you're set up to interact with code shared on Github.
+
+If you are totally new to Github, navigate to [Github.com](https://github.com/) and Sign Up for a new account. Read about the [basics of git](https://docs.github.com/en/get-started/getting-started-with-git/set-up-git).
+
+To work with `flepimop` code, you can do some tasks from the Github website, but you'll also need a way to 'clone' the code to your own local computer and keep it up to date with versions hosted online. You can do this either using a user interface like [Github Desktop](https://desktop.github.com/), or, using [`git` ](https://git-scm.com/downloads)commands from the command line. Make sure you have one or both installed.
+
+If you are a veteran user, make sure you're signed in on Github.com and through whatever method you use locally on your computer to interact with Github.
+
+## 🔐 Access the flepiMoP model code
+
+In order to run a model with flepiMoP, you will need to clone the flepiMoP **code** to your machine. 
+
+**To clone the `flepiMoP` code repository:**
+
+* If you're using the command line in a terminal, first navigate to the local directory you'll use as the directory for the files that make up `flepiMoP`. Then, use the command:\
+  `git clone https://github.com/HopkinsIDD/flepiMoP`
+* If you're using Github Desktop, go File -> Clone Repository, switch to the "URL" tab and copy the URL `https://github.com/HopkinsIDD/flepiMoP` there. For the "Local Path" option, make sure you choose your desired directory.
+
+## 🐍 Installing `conda`
+
+In order to complete `flepiMoP` installation, you must have [`conda`](https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html) installed on your machine. `conda` is a tool that will assist you in managing software environments and code packages on your device. To install `conda` follow the directions according to your operating system:
+
+* [Windows](https://docs.conda.io/projects/conda/en/latest/user-guide/install/windows.html)
+* [macOS](https://docs.conda.io/projects/conda/en/latest/user-guide/install/macos.html)
+* [Linux](https://docs.conda.io/projects/conda/en/latest/user-guide/install/linux.html)
+
+We would recommend selecting the `Anaconda Distribution` installer of `conda`.
+
+Once installed, you must set up your `conda` environmnet. To do this, navigate to your `flepiMoP` directory, and run the following commands:
+
+```bash
+conda env create -f /build/renv/conda_environment.yml
+```
+This will create a `conda` environment called `flepimop-env`, that you will activate with the command:
+
+```bash
+conda activate flepimop-env
+```
+
+## ⬇️ Installing flepiMoP packages and dependencies
+
+While in the `flepiMoP` directory, run the following command:
+
+```bash
+/build/local_install_or_update.sh
+```
+
+This command will install the flepiMoP Python package, `gempyor`, along with all its dependencies, as well as all necessary R packages and dependencies. 


### PR DESCRIPTION
Created two files (`local-installation.md` and `local_install_or_update.sh`) that will likely make it easier for new flepiMoP users to install flepiMoP onto their machine.

### Describe your changes.

This pull request creates a new section of documentation (in a file called `local-installation.md`) that delineates more up-to-date installation instructions for new flepiMoP users. Within these instructions, users are instructed to run a bash script (also created in this PR: `local_install_or_update.sh`). This script:

- automatically sets the environment variable `FLEPI_PATH` to be equal to the current working directory and tests that this is the right directory (exits on fail with message)
- Verifies that the user's `conda` environment is set up correctly and aligns with demands of flepiMoP (exits on fail with message)
- installs `gempyor` + dependencies and all R packages + dependencies 

**Important note:** The existence `local-installation.md` documentation page renders some information on other documentation pages redundant or outdated, so I will need to go back and adjust accordingly after I get a thumbs up on the general structure of these two files! @TimothyWillard 


### Does this pull request make any user interface changes? If so please describe.

The user interface changes are slightly altered local installation instructions for flepiMoP.
Those are reflected in updates to the documentation in `local-installation.md`.


### What does your pull request address? Tag relevant issues.

This pull request addresses GH #401 . 

