### PR TITLE
Correct Formula For Poisson Log-Likelihood

### DIFF
--- a/flepimop/gempyor_pkg/src/gempyor/statistics.py
+++ b/flepimop/gempyor_pkg/src/gempyor/statistics.py
@@ -244,8 +244,8 @@ class Statistic:
         """
 
         dist_map = {
-            "pois": lambda ymodel, ydata: -(ymodel + 1)
-            + ydata * np.log(ymodel + 1)
+            "pois": lambda ydata, ymodel: -ymodel
+            + (ydata * np.log(ymodel))
             - gammaln(ydata + 1),
             # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
             # OLD: # TODO: Swap out in favor of NEW

--- a/flepimop/gempyor_pkg/tests/statistics/test_statistic_class.py
+++ b/flepimop/gempyor_pkg/tests/statistics/test_statistic_class.py
@@ -240,20 +240,12 @@ def simple_valid_factory_with_pois() -> MockStatisticInput:
                 list(data_coords.keys()),
                 np.random.poisson(lam=20.0, size=data_dim),
             ),
-            "incidD": (
-                list(data_coords.keys()),
-                np.random.poisson(lam=20.0, size=data_dim),
-            ),
         },
         coords=data_coords,
     )
     gt_data = xr.Dataset(
         data_vars={
             "incidH": (
-                list(data_coords.keys()),
-                np.random.poisson(lam=20.0, size=data_dim),
-            ),
-            "incidD": (
                 list(data_coords.keys()),
                 np.random.poisson(lam=20.0, size=data_dim),
             ),
@@ -287,10 +279,10 @@ def simple_valid_factory_with_pois_with_some_zeros() -> MockStatisticInput:
         }
     ] = 0
 
-    mock_input.gt_data["incidD"].loc[
+    mock_input.gt_data["incidH"].loc[
         {
-            "date": mock_input.gt_data.coords["date"][0],
-            "subpop": mock_input.gt_data.coords["subpop"][0],
+            "date": mock_input.gt_data.coords["date"][2],
+            "subpop": mock_input.gt_data.coords["subpop"][2],
         }
     ] = 0
 

--- a/flepimop/gempyor_pkg/tests/statistics/test_statistic_class.py
+++ b/flepimop/gempyor_pkg/tests/statistics/test_statistic_class.py
@@ -228,11 +228,59 @@ def simple_valid_resample_and_scale_factory() -> MockStatisticInput:
     )
 
 
+def simple_valid_factory_with_pois() -> MockStatisticInput:
+    data_coords = {
+        "date": pd.date_range(date(2024, 1, 1), date(2024, 1, 10)),
+        "subpop": ["01", "02", "03"],
+    }
+    data_dim = [len(v) for v in data_coords.values()]
+    model_data = xr.Dataset(
+        data_vars={
+            "incidH": (
+                list(data_coords.keys()),
+                np.random.poisson(lam=20.0, size=data_dim),
+            ),
+            "incidD": (
+                list(data_coords.keys()),
+                np.random.poisson(lam=20.0, size=data_dim),
+            ),
+        },
+        coords=data_coords,
+    )
+    gt_data = xr.Dataset(
+        data_vars={
+            "incidH": (
+                list(data_coords.keys()),
+                np.random.poisson(lam=20.0, size=data_dim),
+            ),
+            "incidD": (
+                list(data_coords.keys()),
+                np.random.poisson(lam=20.0, size=data_dim),
+            ),
+        },
+        coords=data_coords,
+    )
+    return MockStatisticInput(
+        "total_hospitalizations",
+        {
+            "name": "sum_hospitalizations",
+            "sim_var": "incidH",
+            "data_var": "incidH",
+            "remove_na": True,
+            "add_one": True,
+            "likelihood": {"dist": "pois"},
+        },
+        model_data=model_data,
+        gt_data=gt_data,
+    )
+
+
 all_valid_factories = [
     (simple_valid_factory),
     (simple_valid_resample_factory),
     (simple_valid_resample_factory),
     (simple_valid_resample_and_scale_factory),
+    (simple_valid_factory_with_pois),
 ]
 
 


### PR DESCRIPTION
### Describe your changes.

Per this comment https://github.com/HopkinsIDD/flepiMoP/pull/375#discussion_r1874023191 corrected the formula for the poisson log-likelihood, including swapping the `ymodel` and `ydata` so it matches prior poisson likelihood. Added a unit test case to demonstrate this change is to restore current behavior.

### Does this pull request make any user interface changes? If so please describe.

This change does not present any user interface changes, but instead fixes behavior in the `dev` branch.