### PR TITLE
Add explicit types to `pull_request` trigger

### DIFF
--- a/.github/workflows/conda-env.yml
+++ b/.github/workflows/conda-env.yml
@@ -9,6 +9,12 @@ on:
     branches:
       - dev
   pull_request:
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
     paths:
       - build/create_environment_yml.R
       - flepimop/R_packages/*/DESCRIPTION

--- a/.github/workflows/flepicommon-ci.yml
+++ b/.github/workflows/flepicommon-ci.yml
@@ -8,6 +8,12 @@ on:
     branches:
       - dev
   pull_request:
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
     paths:
       - flepimop/R_packages/flepicommon/**/*
     branches:

--- a/.github/workflows/gempyor-ci.yml
+++ b/.github/workflows/gempyor-ci.yml
@@ -9,6 +9,12 @@ on:
     branches:
       - dev
   pull_request:
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
     paths:
       - examples/**/*
       - flepimop/gempyor_pkg/**/*

--- a/.github/workflows/inference-ci.yml
+++ b/.github/workflows/inference-ci.yml
@@ -12,6 +12,12 @@ on:
     branches:
       - dev
   pull_request:
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
     paths:
       - flepimop/R_packages/inference/**/*
     branches:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,12 @@ on:
     paths:
       - 'flepimop/gempyor_pkg/**/*.py'
   pull_request:
+    types:
+      - edited
+      - opened
+      - ready_for_review
+      - reopened
+      - synchronize
     paths:
       - '**/*.py'
     branches:


### PR DESCRIPTION
### Describe your changes.

This pull request modifies the pull request related triggers slightly (see below). This is being merged into `main` instead of `dev` because we want to maintain a consistent set of actions across branches (workflow is determined by base branch) and will pull these edits from `main` back into `dev` after merging.

### Does this pull request make any user interface changes? If so please describe.

The user interface changes are the CI GitHub actions will now trigger when a PR is edited (most importantly for GH-412 when the target branch is changed) and when a PR is changed from draft to ready for review. The previous pull request triggers for actions still hold as well.

### What does your pull request address? Tag relevant issues.

This pull request addresses GH-412.