### PR TITLE
Adding `check_parameter_positivity()` function to `seir.py`

### DIFF
--- a/flepimop/gempyor_pkg/src/gempyor/seir.py
+++ b/flepimop/gempyor_pkg/src/gempyor/seir.py
@@ -16,7 +16,7 @@ from .utils import Timer, read_df
 logger = logging.getLogger(__name__)
 
 # TO DO: Write documentation for this function
-def neg_params(
+def check_parameter_positivity(
         parsed_parameters: np.ndarray, 
         parameter_names: list[str], 
         dates: pd.DatetimeIndex, 
@@ -160,7 +160,7 @@ def build_step_source_arg(
         "stochastic_p": modinf.stoch_traj_flag,
     }
 
-    neg_params(
+    check_parameter_positivity(
         fnct_args["parameters"],
         modinf.parameters.pnames,
         modinf.dates,

--- a/flepimop/gempyor_pkg/src/gempyor/seir.py
+++ b/flepimop/gempyor_pkg/src/gempyor/seir.py
@@ -54,20 +54,13 @@ def check_parameter_positivity(
             negative_index_parameters, (redundant_rows), axis=0
         )
 
-        # TO DO: Fix error message such that the print() statement occurs within the ValueError
-        print("The earliest date negative for each subpop and unique parameter are:")
+        error_message = "The earliest date negative for each subpop and unique parameter are:\n"
         for param_idx, day_idx, sp_idx in non_redundant_negative_parameters:
-            print(
-                "subpop: ",
-                subpop_names[sp_idx],
-                ", parameter ",
-                parameter_names[param_idx],
-                ": ",
-                dates[day_idx].date(),
-                sep="",
+            error_message += (
+                f"subpop: {subpop_names[sp_idx]}, parameter {parameter_names[param_idx]}: {dates[day_idx].date()}\n"
             )
         raise ValueError(
-            "There are negative parsed-parameters, which is likely to result in incorrect integration."
+            f"There are negative parsed-parameters, which is likely to result in incorrect integration.\n{error_message}"
         )
 
 

--- a/flepimop/gempyor_pkg/src/gempyor/seir.py
+++ b/flepimop/gempyor_pkg/src/gempyor/seir.py
@@ -54,11 +54,11 @@ def check_parameter_positivity(
             negative_index_parameters, (redundant_rows), axis=0
         )
 
-        error_message = "The earliest date negative for each subpop and unique parameter are:\n"
+        error_message = (
+            "The earliest date negative for each subpop and unique parameter are:\n"
+        )
         for param_idx, day_idx, sp_idx in non_redundant_negative_parameters:
-            error_message += (
-                f"subpop: {subpop_names[sp_idx]}, parameter {parameter_names[param_idx]}: {dates[day_idx].date()}\n"
-            )
+            error_message += f"subpop: {subpop_names[sp_idx]}, parameter {parameter_names[param_idx]}: {dates[day_idx].date()}\n"
         raise ValueError(
             f"There are negative parsed-parameters, which is likely to result in incorrect integration.\n{error_message}"
         )

--- a/flepimop/gempyor_pkg/src/gempyor/seir.py
+++ b/flepimop/gempyor_pkg/src/gempyor/seir.py
@@ -16,7 +16,6 @@ from .utils import Timer, read_df
 logger = logging.getLogger(__name__)
 
 
-# TO DO: Write documentation for this function
 def check_parameter_positivity(
     parsed_parameters: np.ndarray,
     parameter_names: list[str],
@@ -39,8 +38,7 @@ def check_parameter_positivity(
     Returns:
         None
     """
-    if ((parsed_parameters) < 0).any():
-        negative_index_parameters = np.argwhere(parsed_parameters < 0)
+    if len(negative_index_parameters := np.argwhere(parsed_parameters < 0)) > 0:
         unique_param_sp_combinations = []
         row_index = -1
         redundant_rows = []

--- a/flepimop/gempyor_pkg/src/gempyor/seir.py
+++ b/flepimop/gempyor_pkg/src/gempyor/seir.py
@@ -16,13 +16,27 @@ from .utils import Timer, read_df
 logger = logging.getLogger(__name__)
 
 # TO DO: Write documentation for this function
-# TO DO: include dtype hints for arguments
 def neg_params(
         parsed_parameters: np.ndarray, 
         parameter_names: list[str], 
         dates: pd.DatetimeIndex, 
         subpop_names: list[str]
 ) -> None:
+    """
+    Identifies and reports earliest negative values for parameters.
+
+    Args:
+        parsed_parameters: An array of parameter values.
+        parameter_names: A list of the names of parameters.
+        dates: A pandas DatetimeIndex containing the dates.
+        subpop_names: A list of the names of subpopulations.
+
+    Raises:
+        ValueError: Negative parameter values were detected. 
+
+    Returns:
+        None
+    """
     if ((parsed_parameters)< 0).any():
         negative_index_parameters = np.argwhere(parsed_parameters<0)  
         unique_param_sp_combinations = []

--- a/flepimop/gempyor_pkg/src/gempyor/seir.py
+++ b/flepimop/gempyor_pkg/src/gempyor/seir.py
@@ -23,7 +23,8 @@ def check_parameter_positivity(
         subpop_names: list[str]
 ) -> None:
     """
-    Identifies and reports earliest negative values for parameters.
+    Identifies and reports earliest negative values for 
+    parameters after modifiers have been applied.
 
     Args:
         parsed_parameters: An array of parameter values.

--- a/flepimop/gempyor_pkg/src/gempyor/seir.py
+++ b/flepimop/gempyor_pkg/src/gempyor/seir.py
@@ -54,7 +54,7 @@ def check_parameter_positivity(
         neg_subpops = []
         neg_params = []
         first_neg_date = dates[0].date()
-        for param_idx, day_idx, sp_idx in non_redundant_negative_parameters:
+        for param_idx, _, sp_idx in non_redundant_negative_parameters:
             neg_subpops.append(subpop_names[sp_idx])
             neg_params.append(parameter_names[param_idx])
         error_message = f"There are negative parameter errors in subpops {neg_subpops}, starting from date {first_neg_date} in parameters {neg_params}."

--- a/flepimop/gempyor_pkg/src/gempyor/seir.py
+++ b/flepimop/gempyor_pkg/src/gempyor/seir.py
@@ -50,7 +50,7 @@ def check_parameter_positivity(
         non_redundant_negative_parameters = np.delete(
             negative_index_parameters, (redundant_rows), axis=0
         )
-        
+
         neg_subpops = []
         neg_params = []
         first_neg_date = dates[0].date()

--- a/flepimop/gempyor_pkg/src/gempyor/seir.py
+++ b/flepimop/gempyor_pkg/src/gempyor/seir.py
@@ -15,15 +15,16 @@ from .utils import Timer, read_df
 
 logger = logging.getLogger(__name__)
 
+
 # TO DO: Write documentation for this function
 def check_parameter_positivity(
-        parsed_parameters: np.ndarray, 
-        parameter_names: list[str], 
-        dates: pd.DatetimeIndex, 
-        subpop_names: list[str]
+    parsed_parameters: np.ndarray,
+    parameter_names: list[str],
+    dates: pd.DatetimeIndex,
+    subpop_names: list[str],
 ) -> None:
     """
-    Identifies and reports earliest negative values for 
+    Identifies and reports earliest negative values for
     parameters after modifiers have been applied.
 
     Args:
@@ -33,29 +34,42 @@ def check_parameter_positivity(
         subpop_names: A list of the names of subpopulations.
 
     Raises:
-        ValueError: Negative parameter values were detected. 
+        ValueError: Negative parameter values were detected.
 
     Returns:
         None
     """
-    if ((parsed_parameters)< 0).any():
-        negative_index_parameters = np.argwhere(parsed_parameters<0)  
+    if ((parsed_parameters) < 0).any():
+        negative_index_parameters = np.argwhere(parsed_parameters < 0)
         unique_param_sp_combinations = []
         row_index = -1
         redundant_rows = []
         for row in negative_index_parameters:
             row_index += 1
-            if (row[0],row[2]) in unique_param_sp_combinations: 
+            if (row[0], row[2]) in unique_param_sp_combinations:
                 redundant_rows.append(row_index)
-            if (row[0],row[2]) not in unique_param_sp_combinations: 
-                unique_param_sp_combinations.append((row[0],row[2]))
-        non_redundant_negative_parameters = np.delete(negative_index_parameters, (redundant_rows), axis=0)
+            if (row[0], row[2]) not in unique_param_sp_combinations:
+                unique_param_sp_combinations.append((row[0], row[2]))
+        non_redundant_negative_parameters = np.delete(
+            negative_index_parameters, (redundant_rows), axis=0
+        )
 
         # TO DO: Fix error message such that the print() statement occurs within the ValueError
         print("The earliest date negative for each subpop and unique parameter are:")
         for param_idx, day_idx, sp_idx in non_redundant_negative_parameters:
-            print("subpop: ", subpop_names[sp_idx], ", parameter ", parameter_names[param_idx], ": ", dates[day_idx].date(), sep="")
-        raise ValueError("There are negative parsed-parameters, which is likely to result in incorrect integration.")
+            print(
+                "subpop: ",
+                subpop_names[sp_idx],
+                ", parameter ",
+                parameter_names[param_idx],
+                ": ",
+                dates[day_idx].date(),
+                sep="",
+            )
+        raise ValueError(
+            "There are negative parsed-parameters, which is likely to result in incorrect integration."
+        )
+
 
 def build_step_source_arg(
     modinf: ModelInfo,
@@ -162,10 +176,7 @@ def build_step_source_arg(
     }
 
     check_parameter_positivity(
-        fnct_args["parameters"],
-        modinf.parameters.pnames,
-        modinf.dates,
-        modinf.subpop_pop
+        fnct_args["parameters"], modinf.parameters.pnames, modinf.dates, modinf.subpop_pop
     )
 
     return fnct_args

--- a/flepimop/gempyor_pkg/src/gempyor/seir.py
+++ b/flepimop/gempyor_pkg/src/gempyor/seir.py
@@ -23,8 +23,7 @@ def check_parameter_positivity(
     subpop_names: list[str],
 ) -> None:
     """
-    Identifies and reports earliest negative values for
-    parameters after modifiers have been applied.
+    Identifies and reports earliest negative values for parameters after modifiers have been applied.
 
     Args:
         parsed_parameters: An array of parameter values.
@@ -51,15 +50,15 @@ def check_parameter_positivity(
         non_redundant_negative_parameters = np.delete(
             negative_index_parameters, (redundant_rows), axis=0
         )
-
-        error_message = (
-            "The earliest date negative for each subpop and unique parameter are:\n"
-        )
+        
+        neg_subpops = []
+        neg_params = []
+        first_neg_date = dates[0].date()
         for param_idx, day_idx, sp_idx in non_redundant_negative_parameters:
-            error_message += f"subpop: {subpop_names[sp_idx]}, parameter {parameter_names[param_idx]}: {dates[day_idx].date()}\n"
-        raise ValueError(
-            f"There are negative parsed-parameters, which is likely to result in incorrect integration.\n{error_message}"
-        )
+            neg_subpops.append(subpop_names[sp_idx])
+            neg_params.append(parameter_names[param_idx])
+        error_message = f"There are negative parameter errors in subpops {neg_subpops}, starting from date {first_neg_date} in parameters {neg_params}."
+        raise ValueError(f"{error_message}")
 
 
 def build_step_source_arg(

--- a/flepimop/gempyor_pkg/tests/seir/test_seir.py
+++ b/flepimop/gempyor_pkg/tests/seir/test_seir.py
@@ -72,7 +72,7 @@ def test_check_parameter_positivity():
 
     with pytest.raises(
         ValueError,
-        match=(rf"There are negative parameter errors in subpops \{test_2_neg_subpops}\.*"),
+        match=(rf"There are negative parameter errors in subpops \\{test_2_neg_subpops}\\.*"),
     ):
         seir.check_parameter_positivity(
             test_array2, parameter_names, dates, subpop_names
@@ -98,7 +98,7 @@ def test_check_parameter_positivity():
 
     with pytest.raises(
         ValueError,
-        match=(rf"There are negative parameter errors in subpops \{test_3_neg_subpops}\.*"),
+        match=(rf"There are negative parameter errors in subpops \\{test_3_neg_subpops}\\.*"),
     ):
         seir.check_parameter_positivity(
             test_array3, parameter_names, dates, subpop_names

--- a/flepimop/gempyor_pkg/tests/seir/test_seir.py
+++ b/flepimop/gempyor_pkg/tests/seir/test_seir.py
@@ -40,7 +40,7 @@ def test_check_parameter_positivity():
     randint_second_dim = randint(0,len(dates)-2)
     randint_third_dim = randint(0,len(subpop_names)-1)
     test_array3[0][0][0] = -1
-    test_array3[randint(0,len(parameter_names)),randint(0,len(dates)):,randint(0,len(subpop_names))] = -1
+    test_array3[randint(0,len(parameter_names)-1),randint(0,len(dates)-1):,randint(0,len(subpop_names)-1)] = -1
     test_array3[randint_first_dim][randint_second_dim][randint_third_dim] = -1
     test_array3[randint_first_dim][randint_second_dim+1][randint_third_dim] = -1
 

--- a/flepimop/gempyor_pkg/tests/seir/test_seir.py
+++ b/flepimop/gempyor_pkg/tests/seir/test_seir.py
@@ -5,6 +5,7 @@ import warnings
 import shutil
 from random import randint
 import pandas as pd
+import re
 
 import pathlib
 import pyarrow as pa
@@ -75,7 +76,7 @@ def test_check_parameter_positivity():
 
     with pytest.raises(
         ValueError,
-        match=(
+        match=re.escape(
             rf"There are negative parameter errors in subpops {test_2_neg_subpops}, starting from date {test_2_first_neg_date} in parameters {test_2_neg_params}."
         ),
     ):
@@ -83,20 +84,13 @@ def test_check_parameter_positivity():
             test_array2, parameter_names, dates, subpop_names
         )  # ValueError
 
-    # Set negative params with intentional redundancy
+    # Manually set negative params with intentional redundancy
     test_array3 = np.zeros((len(parameter_names), len(dates), len(subpop_names)))
-    randint_first_dim = randint(0, len(parameter_names) - 1)
-    randint_second_dim = randint(0, len(dates) - 2)
-    randint_third_dim = randint(0, len(subpop_names) - 1)
-    test_array3[0][0][0] = -1
-    test_array3[
-        randint(0, len(parameter_names) - 1),
-        randint(0, len(dates) - 1) :,
-        randint(0, len(subpop_names) - 1),
-    ] = -1
-    test_array3[randint_first_dim][randint_second_dim][randint_third_dim] = -1
-    test_array3[randint_first_dim][randint_second_dim + 1][randint_third_dim] = -1
-    test_3_negative_index_parameters = np.argwhere(test_array2 < 0)
+    test_array3[0, 0, 0] = -1
+    test_array3[1, 1, 1] = -1
+    test_array3[2, 2, 2] = -1
+    test_array3[3, 3, 3] = -1
+    test_3_negative_index_parameters = np.argwhere(test_array3 < 0)
     test_3_neg_params = []
     test_3_neg_subpops = []
     test_3_first_neg_date = dates[0].date()
@@ -106,7 +100,7 @@ def test_check_parameter_positivity():
 
     with pytest.raises(
         ValueError,
-        match=(
+        match=re.escape(
             rf"There are negative parameter errors in subpops {test_3_neg_subpops}, starting from date {test_3_first_neg_date} in parameters {test_3_neg_params}."
         ),
     ):

--- a/flepimop/gempyor_pkg/tests/seir/test_seir.py
+++ b/flepimop/gempyor_pkg/tests/seir/test_seir.py
@@ -68,7 +68,7 @@ def test_check_parameter_positivity():
     test_2_negative_index_parameters = np.argwhere(test_array2 < 0)
     test_2_neg_params = []
     test_2_neg_subpops = []
-    test_2_first_neg_date = dates[0].date
+    test_2_first_neg_date = dates[0].date()
     for param_idx, _, sp_idx in test_2_negative_index_parameters:
         test_2_neg_subpops.append(subpop_names[sp_idx])
         test_2_neg_params.append(parameter_names[param_idx])
@@ -99,7 +99,7 @@ def test_check_parameter_positivity():
     test_3_negative_index_parameters = np.argwhere(test_array2 < 0)
     test_3_neg_params = []
     test_3_neg_subpops = []
-    test_3_first_neg_date = dates[0].date
+    test_3_first_neg_date = dates[0].date()
     for param_idx, _, sp_idx in test_3_negative_index_parameters:
         test_3_neg_subpops.append(subpop_names[sp_idx])
         test_3_neg_params.append(parameter_names[param_idx])

--- a/flepimop/gempyor_pkg/tests/seir/test_seir.py
+++ b/flepimop/gempyor_pkg/tests/seir/test_seir.py
@@ -18,14 +18,15 @@ DATA_DIR = os.path.dirname(__file__) + "/data"
 os.chdir(os.path.dirname(__file__))
 
 def test_neg_params():
+    
+    config.set_file(f"{DATA_DIR}/config.yml")
     modinf = model_info.ModelInfo(
         config=config,
         nslots=1,
         seir_modifiers_scenario="None",
         write_csv=False,
     )
-        
-    modinf = model_info.ModelInfo()
+
     parameter_names = modinf.parameters.pnames
     dates = modinf.dates
     subpop_names = modinf.subpop_pop
@@ -56,6 +57,7 @@ def test_neg_params():
 
 
 def test_check_values():
+    # I think line 61 could be deleted...redundant b/c this also occurs outside func def
     os.chdir(os.path.dirname(__file__))
     config.set_file(f"{DATA_DIR}/config.yml")
 

--- a/flepimop/gempyor_pkg/tests/seir/test_seir.py
+++ b/flepimop/gempyor_pkg/tests/seir/test_seir.py
@@ -44,11 +44,11 @@ def test_check_parameter_positivity():
     test_array3[randint_first_dim][randint_second_dim][randint_third_dim] = -1
     test_array3[randint_first_dim][randint_second_dim+1][randint_third_dim] = -1
 
-    seir.neg_params(test_array1, parameter_names, dates, subpop_names) # NoError
+    seir.check_parameter_positivity(test_array1, parameter_names, dates, subpop_names) # NoError
 
     with pytest.raises(ValueError):
-        assert seir.neg_params(test_array2, parameter_names, dates, subpop_names) # ValueError
-        assert seir.neg_params(test_array3, parameter_names, dates, subpop_names) # ValueError
+        assert seir.check_parameter_positivity(test_array2, parameter_names, dates, subpop_names) # ValueError
+        assert seir.check_parameter_positivity(test_array3, parameter_names, dates, subpop_names) # ValueError
 
 
 def test_check_values():

--- a/flepimop/gempyor_pkg/tests/seir/test_seir.py
+++ b/flepimop/gempyor_pkg/tests/seir/test_seir.py
@@ -72,9 +72,7 @@ def test_check_parameter_positivity():
 
     with pytest.raises(
         ValueError,
-        match=(
-            rf"There are negative parameter errors in subpops {test_2_neg_subpops}"
-        ),
+        match=(rf"There are negative parameter errors in subpops {test_2_neg_subpops}"),
     ):
         seir.check_parameter_positivity(
             test_array2, parameter_names, dates, subpop_names
@@ -100,9 +98,7 @@ def test_check_parameter_positivity():
 
     with pytest.raises(
         ValueError,
-        match=(
-            rf"TThere are negative parameter errors in subpops {test_3_neg_subpops}"
-        ),
+        match=(rf"TThere are negative parameter errors in subpops {test_3_neg_subpops}"),
     ):
         seir.check_parameter_positivity(
             test_array3, parameter_names, dates, subpop_names

--- a/flepimop/gempyor_pkg/tests/seir/test_seir.py
+++ b/flepimop/gempyor_pkg/tests/seir/test_seir.py
@@ -72,7 +72,7 @@ def test_check_parameter_positivity():
 
     with pytest.raises(
         ValueError,
-        match=(rf"There are negative parameter errors in subpops {test_2_neg_subpops}"),
+        match=(rf"There are negative parameter errors in subpops {test_2_neg_subpops}.*"),
     ):
         seir.check_parameter_positivity(
             test_array2, parameter_names, dates, subpop_names
@@ -98,7 +98,7 @@ def test_check_parameter_positivity():
 
     with pytest.raises(
         ValueError,
-        match=(rf"TThere are negative parameter errors in subpops {test_3_neg_subpops}"),
+        match=(rf"TThere are negative parameter errors in subpops {test_3_neg_subpops}.*"),
     ):
         seir.check_parameter_positivity(
             test_array3, parameter_names, dates, subpop_names

--- a/flepimop/gempyor_pkg/tests/seir/test_seir.py
+++ b/flepimop/gempyor_pkg/tests/seir/test_seir.py
@@ -5,7 +5,6 @@ import warnings
 import shutil
 from random import randint
 import pandas as pd
-import re
 
 import pathlib
 import pyarrow as pa
@@ -67,14 +66,18 @@ def test_check_parameter_positivity():
             randint(0, len(subpop_names) - 1)
         ] = -1
     test_2_negative_index_parameters = np.argwhere(test_array2 < 0)
+    test_2_neg_params = []
     test_2_neg_subpops = []
-    for _, _, sp_idx in test_2_negative_index_parameters:
+    test_2_first_neg_date = dates[0].date
+    for param_idx, _, sp_idx in test_2_negative_index_parameters:
         test_2_neg_subpops.append(subpop_names[sp_idx])
-    test_2_neg_subpops = str(test_2_neg_subpops)
+        test_2_neg_params.append(parameter_names[param_idx])
 
     with pytest.raises(
         ValueError,
-        match=(rf"There are negative parameter errors in subpops {test_2_neg_subpops}.*"),
+        match=(
+            rf"There are negative parameter errors in subpops {test_2_neg_subpops}, starting from date {test_2_first_neg_date} in parameters {test_2_neg_params}."
+        ),
     ):
         seir.check_parameter_positivity(
             test_array2, parameter_names, dates, subpop_names
@@ -94,14 +97,18 @@ def test_check_parameter_positivity():
     test_array3[randint_first_dim][randint_second_dim][randint_third_dim] = -1
     test_array3[randint_first_dim][randint_second_dim + 1][randint_third_dim] = -1
     test_3_negative_index_parameters = np.argwhere(test_array2 < 0)
+    test_3_neg_params = []
     test_3_neg_subpops = []
-    for _, _, sp_idx in test_3_negative_index_parameters:
+    test_3_first_neg_date = dates[0].date
+    for param_idx, _, sp_idx in test_3_negative_index_parameters:
         test_3_neg_subpops.append(subpop_names[sp_idx])
-    test_3_neg_subpops = str(test_3_neg_subpops)
+        test_3_neg_params.append(parameter_names[param_idx])
 
     with pytest.raises(
         ValueError,
-        match=(rf"There are negative parameter errors in subpops {test_3_neg_subpops}.*"),
+        match=(
+            rf"There are negative parameter errors in subpops {test_3_neg_subpops}, starting from date {test_3_first_neg_date} in parameters {test_3_neg_params}."
+        ),
     ):
         seir.check_parameter_positivity(
             test_array3, parameter_names, dates, subpop_names

--- a/flepimop/gempyor_pkg/tests/seir/test_seir.py
+++ b/flepimop/gempyor_pkg/tests/seir/test_seir.py
@@ -26,15 +26,15 @@ def test_check_parameter_positivity():
     dates = pd.date_range('2023-03-19', '2025-04-30', freq="D")
     subpop_names = ['56000', '50000', '11000', '02000', '38000', '46000', '10000', '30000', '44000', '23000']
 
-    # Test case 1: no negative params
+    # No negative params
     test_array1 = np.zeros((len(parameter_names)-1, len(dates)-1, len(subpop_names)-1))
     
-    # Test case 2: randomized negative params
+    # Randomized negative params
     test_array2 = np.zeros((len(parameter_names)-1,len(dates)-1,len(subpop_names)-1))
     for _ in range(5):
         test_array2[randint(0,len(parameter_names)-1)][randint(0,len(dates)-1)][randint(0,len(subpop_names)-1)] = -1
 
-    # Test case 3: set negative params with intentional redundancy
+    # Set negative params with intentional redundancy
     test_array3 = np.zeros((len(parameter_names),len(dates),len(subpop_names)))
     randint_first_dim = randint(0,len(parameter_names)-1)
     randint_second_dim = randint(0,len(dates)-2)
@@ -52,8 +52,6 @@ def test_check_parameter_positivity():
 
 
 def test_check_values():
-    # I think line 61 could be deleted...redundant b/c this also occurs outside func def
-    os.chdir(os.path.dirname(__file__))
     config.set_file(f"{DATA_DIR}/config.yml")
 
     modinf = model_info.ModelInfo(

--- a/flepimop/gempyor_pkg/tests/seir/test_seir.py
+++ b/flepimop/gempyor_pkg/tests/seir/test_seir.py
@@ -17,19 +17,14 @@ from gempyor.utils import config
 DATA_DIR = os.path.dirname(__file__) + "/data"
 os.chdir(os.path.dirname(__file__))
 
-def test_neg_params():
-    
-    config.set_file(f"{DATA_DIR}/config.yml")
-    modinf = model_info.ModelInfo(
-        config=config,
-        nslots=1,
-        seir_modifiers_scenario="None",
-        write_csv=False,
-    )
+def test_check_parameter_positivity():
 
-    parameter_names = modinf.parameters.pnames
-    dates = modinf.dates
-    subpop_names = modinf.subpop_pop
+    parameter_names = ['alpha*1*1*1', 'sigma_OMICRON*1*1*1', '3*gamma*1*1*1', 'epsilon+omegaph4*1*1*1', 
+                       '1*zeta*1*1', 'r0*gamma*theta10*1*chi_OMICRON*1', 'r0*gamma*theta9*1*chi_OMICRON*1', 
+                       'eta_X0toX3_highIE*1*1*nuage0to17', 'eta_X0toX3_highIE*1*1*nuage18to64LR', 
+                       'eta_X0toX3_highIE*1*1*nuage18to64HR', 'eta_X0toX3_highIE*1*1*nuage65to100',]
+    dates = pd.date_range('2023-03-19', '2025-04-31', freq="D")
+    subpop_names = ['56000', '50000', '11000', '02000', '38000', '46000', '10000', '30000', '44000', '23000']
 
     # Test case 1: no negative params
     test_array1 = np.zeros((len(parameter_names)-1, len(dates)-1, len(subpop_names)-1))

--- a/flepimop/gempyor_pkg/tests/seir/test_seir.py
+++ b/flepimop/gempyor_pkg/tests/seir/test_seir.py
@@ -66,9 +66,9 @@ def test_check_parameter_positivity():
             randint(0, len(subpop_names) - 1)
         ] = -1
     test_2_negative_index_parameters = np.argwhere(test_array2 < 0)
-    test_2_neg_subpops = set()
+    test_2_neg_subpops = []
     for _, _, sp_idx in test_2_negative_index_parameters:
-        test_2_neg_subpops.add(subpop_names[sp_idx])
+        test_2_neg_subpops.append(subpop_names[sp_idx])
 
     with pytest.raises(
         ValueError,
@@ -92,9 +92,9 @@ def test_check_parameter_positivity():
     test_array3[randint_first_dim][randint_second_dim][randint_third_dim] = -1
     test_array3[randint_first_dim][randint_second_dim + 1][randint_third_dim] = -1
     test_3_negative_index_parameters = np.argwhere(test_array2 < 0)
-    test_3_neg_subpops = set()
+    test_3_neg_subpops = []
     for _, _, sp_idx in test_3_negative_index_parameters:
-        test_3_neg_subpops.add(subpop_names[sp_idx])
+        test_3_neg_subpops.append(subpop_names[sp_idx])
 
     with pytest.raises(
         ValueError,

--- a/flepimop/gempyor_pkg/tests/seir/test_seir.py
+++ b/flepimop/gempyor_pkg/tests/seir/test_seir.py
@@ -23,7 +23,7 @@ def test_check_parameter_positivity():
                        '1*zeta*1*1', 'r0*gamma*theta10*1*chi_OMICRON*1', 'r0*gamma*theta9*1*chi_OMICRON*1', 
                        'eta_X0toX3_highIE*1*1*nuage0to17', 'eta_X0toX3_highIE*1*1*nuage18to64LR', 
                        'eta_X0toX3_highIE*1*1*nuage18to64HR', 'eta_X0toX3_highIE*1*1*nuage65to100',]
-    dates = pd.date_range('2023-03-19', '2025-04-31', freq="D")
+    dates = pd.date_range('2023-03-19', '2025-04-30', freq="D")
     subpop_names = ['56000', '50000', '11000', '02000', '38000', '46000', '10000', '30000', '44000', '23000']
 
     # Test case 1: no negative params

--- a/flepimop/gempyor_pkg/tests/seir/test_seir.py
+++ b/flepimop/gempyor_pkg/tests/seir/test_seir.py
@@ -72,7 +72,7 @@ def test_check_parameter_positivity():
 
     with pytest.raises(
         ValueError,
-        match=(rf"There are negative parameter errors in subpops {test_2_neg_subpops}.*"),
+        match=(rf"There are negative parameter errors in subpops \{test_2_neg_subpops}\.*"),
     ):
         seir.check_parameter_positivity(
             test_array2, parameter_names, dates, subpop_names
@@ -98,7 +98,7 @@ def test_check_parameter_positivity():
 
     with pytest.raises(
         ValueError,
-        match=(rf"TThere are negative parameter errors in subpops {test_3_neg_subpops}.*"),
+        match=(rf"There are negative parameter errors in subpops \{test_3_neg_subpops}\.*"),
     ):
         seir.check_parameter_positivity(
             test_array3, parameter_names, dates, subpop_names

--- a/flepimop/gempyor_pkg/tests/seir/test_seir.py
+++ b/flepimop/gempyor_pkg/tests/seir/test_seir.py
@@ -65,10 +65,15 @@ def test_check_parameter_positivity():
         test_array2[randint(0, len(parameter_names) - 1)][randint(0, len(dates) - 1)][
             randint(0, len(subpop_names) - 1)
         ] = -1
+    test_2_negative_index_parameters = np.argwhere(test_array2 < 0)
+    test_2_neg_subpops = set()
+    for _, _, sp_idx in test_2_negative_index_parameters:
+        test_2_neg_subpops.add(subpop_names[sp_idx])
+
     with pytest.raises(
         ValueError,
         match=(
-            r"There are negative parsed-parameters, which is likely to result in incorrect integration."
+            rf"There are negative parameter errors in subpops {test_2_neg_subpops}"
         ),
     ):
         seir.check_parameter_positivity(
@@ -88,10 +93,15 @@ def test_check_parameter_positivity():
     ] = -1
     test_array3[randint_first_dim][randint_second_dim][randint_third_dim] = -1
     test_array3[randint_first_dim][randint_second_dim + 1][randint_third_dim] = -1
+    test_3_negative_index_parameters = np.argwhere(test_array2 < 0)
+    test_3_neg_subpops = set()
+    for _, _, sp_idx in test_3_negative_index_parameters:
+        test_3_neg_subpops.add(subpop_names[sp_idx])
+
     with pytest.raises(
         ValueError,
         match=(
-            r"There are negative parsed-parameters, which is likely to result in incorrect integration."
+            rf"TThere are negative parameter errors in subpops {test_3_neg_subpops}"
         ),
     ):
         seir.check_parameter_positivity(

--- a/flepimop/gempyor_pkg/tests/seir/test_seir.py
+++ b/flepimop/gempyor_pkg/tests/seir/test_seir.py
@@ -51,6 +51,11 @@ def test_check_parameter_positivity():
     test_array1 = np.zeros(
         (len(parameter_names) - 1, len(dates) - 1, len(subpop_names) - 1)
     )
+    assert (
+        seir.check_parameter_positivity(test_array1, parameter_names, dates, subpop_names)
+        is None
+    )
+    # No Error
 
     # Randomized negative params
     test_array2 = np.zeros(
@@ -60,6 +65,15 @@ def test_check_parameter_positivity():
         test_array2[randint(0, len(parameter_names) - 1)][randint(0, len(dates) - 1)][
             randint(0, len(subpop_names) - 1)
         ] = -1
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"There are negative parsed-parameters, which is likely to result in incorrect integration."
+        ),
+    ):
+        seir.check_parameter_positivity(
+            test_array2, parameter_names, dates, subpop_names
+        )  # ValueError
 
     # Set negative params with intentional redundancy
     test_array3 = np.zeros((len(parameter_names), len(dates), len(subpop_names)))
@@ -74,16 +88,13 @@ def test_check_parameter_positivity():
     ] = -1
     test_array3[randint_first_dim][randint_second_dim][randint_third_dim] = -1
     test_array3[randint_first_dim][randint_second_dim + 1][randint_third_dim] = -1
-
-    seir.check_parameter_positivity(
-        test_array1, parameter_names, dates, subpop_names
-    )  # NoError
-
-    with pytest.raises(ValueError):
-        assert seir.check_parameter_positivity(
-            test_array2, parameter_names, dates, subpop_names
-        )  # ValueError
-        assert seir.check_parameter_positivity(
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"There are negative parsed-parameters, which is likely to result in incorrect integration."
+        ),
+    ):
+        seir.check_parameter_positivity(
             test_array3, parameter_names, dates, subpop_names
         )  # ValueError
 

--- a/flepimop/gempyor_pkg/tests/seir/test_seir.py
+++ b/flepimop/gempyor_pkg/tests/seir/test_seir.py
@@ -5,6 +5,7 @@ import warnings
 import shutil
 from random import randint
 import pandas as pd
+import re
 
 import pathlib
 import pyarrow as pa
@@ -72,7 +73,7 @@ def test_check_parameter_positivity():
 
     with pytest.raises(
         ValueError,
-        match=(f"There are negative parameter errors in subpops {test_2_neg_subpops},"),
+        match=re.escape((rf"There are negative parameter errors in subpops {test_2_neg_subpops}.*")),
     ):
         seir.check_parameter_positivity(
             test_array2, parameter_names, dates, subpop_names
@@ -98,7 +99,7 @@ def test_check_parameter_positivity():
 
     with pytest.raises(
         ValueError,
-        match=(rf"There are negative parameter errors in subpops \\{test_3_neg_subpops}\\.*"),
+        match=re.escape((rf"There are negative parameter errors in subpops {test_3_neg_subpops}.*")),
     ):
         seir.check_parameter_positivity(
             test_array3, parameter_names, dates, subpop_names

--- a/flepimop/gempyor_pkg/tests/seir/test_seir.py
+++ b/flepimop/gempyor_pkg/tests/seir/test_seir.py
@@ -17,38 +17,75 @@ from gempyor.utils import config
 DATA_DIR = os.path.dirname(__file__) + "/data"
 os.chdir(os.path.dirname(__file__))
 
+
 def test_check_parameter_positivity():
 
-    parameter_names = ['alpha*1*1*1', 'sigma_OMICRON*1*1*1', '3*gamma*1*1*1', 'epsilon+omegaph4*1*1*1', 
-                       '1*zeta*1*1', 'r0*gamma*theta10*1*chi_OMICRON*1', 'r0*gamma*theta9*1*chi_OMICRON*1', 
-                       'eta_X0toX3_highIE*1*1*nuage0to17', 'eta_X0toX3_highIE*1*1*nuage18to64LR', 
-                       'eta_X0toX3_highIE*1*1*nuage18to64HR', 'eta_X0toX3_highIE*1*1*nuage65to100',]
-    dates = pd.date_range('2023-03-19', '2025-04-30', freq="D")
-    subpop_names = ['56000', '50000', '11000', '02000', '38000', '46000', '10000', '30000', '44000', '23000']
+    parameter_names = [
+        "alpha*1*1*1",
+        "sigma_OMICRON*1*1*1",
+        "3*gamma*1*1*1",
+        "epsilon+omegaph4*1*1*1",
+        "1*zeta*1*1",
+        "r0*gamma*theta10*1*chi_OMICRON*1",
+        "r0*gamma*theta9*1*chi_OMICRON*1",
+        "eta_X0toX3_highIE*1*1*nuage0to17",
+        "eta_X0toX3_highIE*1*1*nuage18to64LR",
+        "eta_X0toX3_highIE*1*1*nuage18to64HR",
+        "eta_X0toX3_highIE*1*1*nuage65to100",
+    ]
+    dates = pd.date_range("2023-03-19", "2025-04-30", freq="D")
+    subpop_names = [
+        "56000",
+        "50000",
+        "11000",
+        "02000",
+        "38000",
+        "46000",
+        "10000",
+        "30000",
+        "44000",
+        "23000",
+    ]
 
     # No negative params
-    test_array1 = np.zeros((len(parameter_names)-1, len(dates)-1, len(subpop_names)-1))
-    
+    test_array1 = np.zeros(
+        (len(parameter_names) - 1, len(dates) - 1, len(subpop_names) - 1)
+    )
+
     # Randomized negative params
-    test_array2 = np.zeros((len(parameter_names)-1,len(dates)-1,len(subpop_names)-1))
+    test_array2 = np.zeros(
+        (len(parameter_names) - 1, len(dates) - 1, len(subpop_names) - 1)
+    )
     for _ in range(5):
-        test_array2[randint(0,len(parameter_names)-1)][randint(0,len(dates)-1)][randint(0,len(subpop_names)-1)] = -1
+        test_array2[randint(0, len(parameter_names) - 1)][randint(0, len(dates) - 1)][
+            randint(0, len(subpop_names) - 1)
+        ] = -1
 
     # Set negative params with intentional redundancy
-    test_array3 = np.zeros((len(parameter_names),len(dates),len(subpop_names)))
-    randint_first_dim = randint(0,len(parameter_names)-1)
-    randint_second_dim = randint(0,len(dates)-2)
-    randint_third_dim = randint(0,len(subpop_names)-1)
+    test_array3 = np.zeros((len(parameter_names), len(dates), len(subpop_names)))
+    randint_first_dim = randint(0, len(parameter_names) - 1)
+    randint_second_dim = randint(0, len(dates) - 2)
+    randint_third_dim = randint(0, len(subpop_names) - 1)
     test_array3[0][0][0] = -1
-    test_array3[randint(0,len(parameter_names)-1),randint(0,len(dates)-1):,randint(0,len(subpop_names)-1)] = -1
+    test_array3[
+        randint(0, len(parameter_names) - 1),
+        randint(0, len(dates) - 1) :,
+        randint(0, len(subpop_names) - 1),
+    ] = -1
     test_array3[randint_first_dim][randint_second_dim][randint_third_dim] = -1
-    test_array3[randint_first_dim][randint_second_dim+1][randint_third_dim] = -1
+    test_array3[randint_first_dim][randint_second_dim + 1][randint_third_dim] = -1
 
-    seir.check_parameter_positivity(test_array1, parameter_names, dates, subpop_names) # NoError
+    seir.check_parameter_positivity(
+        test_array1, parameter_names, dates, subpop_names
+    )  # NoError
 
     with pytest.raises(ValueError):
-        assert seir.check_parameter_positivity(test_array2, parameter_names, dates, subpop_names) # ValueError
-        assert seir.check_parameter_positivity(test_array3, parameter_names, dates, subpop_names) # ValueError
+        assert seir.check_parameter_positivity(
+            test_array2, parameter_names, dates, subpop_names
+        )  # ValueError
+        assert seir.check_parameter_positivity(
+            test_array3, parameter_names, dates, subpop_names
+        )  # ValueError
 
 
 def test_check_values():

--- a/flepimop/gempyor_pkg/tests/seir/test_seir.py
+++ b/flepimop/gempyor_pkg/tests/seir/test_seir.py
@@ -70,10 +70,11 @@ def test_check_parameter_positivity():
     test_2_neg_subpops = []
     for _, _, sp_idx in test_2_negative_index_parameters:
         test_2_neg_subpops.append(subpop_names[sp_idx])
+    test_2_neg_subpops = str(test_2_neg_subpops)
 
     with pytest.raises(
         ValueError,
-        match=re.escape((rf"There are negative parameter errors in subpops {test_2_neg_subpops}.*")),
+        match=(rf"There are negative parameter errors in subpops {test_2_neg_subpops}.*"),
     ):
         seir.check_parameter_positivity(
             test_array2, parameter_names, dates, subpop_names
@@ -96,10 +97,11 @@ def test_check_parameter_positivity():
     test_3_neg_subpops = []
     for _, _, sp_idx in test_3_negative_index_parameters:
         test_3_neg_subpops.append(subpop_names[sp_idx])
+    test_3_neg_subpops = str(test_3_neg_subpops)
 
     with pytest.raises(
         ValueError,
-        match=re.escape((rf"There are negative parameter errors in subpops {test_3_neg_subpops}.*")),
+        match=(rf"There are negative parameter errors in subpops {test_3_neg_subpops}.*"),
     ):
         seir.check_parameter_positivity(
             test_array3, parameter_names, dates, subpop_names

--- a/flepimop/gempyor_pkg/tests/seir/test_seir.py
+++ b/flepimop/gempyor_pkg/tests/seir/test_seir.py
@@ -72,7 +72,7 @@ def test_check_parameter_positivity():
 
     with pytest.raises(
         ValueError,
-        match=(rf"There are negative parameter errors in subpops \\{test_2_neg_subpops}\\.*"),
+        match=(f"There are negative parameter errors in subpops {test_2_neg_subpops},"),
     ):
         seir.check_parameter_positivity(
             test_array2, parameter_names, dates, subpop_names


### PR DESCRIPTION
### Describe your changes.

This pull request  introduces a function called `check_parameter_positivity()` to `seir.py`. `check_parameter_positivity()` takes in an array of parsed parameters, as well as parameter names, subpopulation names, and dates, checks for the existence of negative parameter values, and throws a `ValueError` error if they are found. When throwing the error, `check_parameter_positivity()` will only print the earliest (w.r.t date) negative parameter to avoid redundant feedback. Example output will resemble:
```
The earliest date negative for each subpop and unique parameter are:
subpop: 50000, parameter eta_X0toX3_highIE*1*1*nuage18to64HR: 2023-07-21
subpop: 32000, parameter eta_X1toX4_highIE*1*1*nuage0to17: 2024-02-15
subpop: 28000, parameter eta_X1toX4_highIE*1*1*nuage18to64LR: 2025-06-01
```

A test function, `test_check_parameter_positivity()` has also been added to `test_seir.py` to test `check_parameter_positivity()`. 


### Does this pull request make any user interface changes? If so please describe.

No changes to the user interface.


### What does your pull request address? Tag relevant issues.

This pull request addresses GH #215.


### Tag relevant team members.

@jcblemai 