### PR TITLE
Add CLI Issue Label To Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,6 +12,7 @@ body:
       options:
         - bug
         - batch
+        - cli
         - config
         - dependency
         - documentation

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -12,6 +12,7 @@ body:
       options:
         - bug
         - batch
+        - cli
         - config
         - dependency
         - documentation


### PR DESCRIPTION
### Describe your changes.

This pull request adds a `cli` label to the issue templates. This is to help tag/group an increasing number of command line related issues. If this PR looks good then I'll actually create the label before merging.
