### PR TITLE
Cluster Info

### DIFF
--- a/.github/workflows/gempyor-ci.yml
+++ b/.github/workflows/gempyor-ci.yml
@@ -49,6 +49,7 @@ jobs:
         shell: bash
       - name: Run gempyor tests
         run: |
+          export FLEPI_PATH=$(pwd)
           cd flepimop/gempyor_pkg
           pytest --exitfirst
         shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths:
       - 'flepimop/gempyor_pkg/**/*.py'
+      - 'info/**/*'
   pull_request:
     types:
       - edited
@@ -14,8 +15,10 @@ on:
       - synchronize
     paths:
       - '**/*.py'
+      - 'info/**/*'
     branches:
       - main
+      - dev
 
 jobs:
   black-for-python:
@@ -45,3 +48,37 @@ jobs:
         with:
           src: ${{ env.BLACK_SRC }}
           options: "--line-length ${{ env.BLACK_LINE_LENGTH }} --extend-exclude '${{ env.BLACK_EXTEND_EXCLUDE }}' --check --verbose"
+  check-info-json-schema:
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+          sparse-checkout: |
+            info
+          sparse-checkout-cone-mode: false
+      - name: Install yq and check-jsonschema
+        run: |
+          sudo apt update
+          sudo apt install snapd
+          sudo snap install yq
+          sudo apt install pipx
+          pipx install check-jsonschema
+      - name: Convert YAML to JSON
+        run: |
+          cd info
+          for d in $( ls ); do
+            cd $d
+            for y in *.yml; do
+              yq --output-format json $y > ${y%.yml}.json
+            done
+            for j in *.json; do
+              if [[ "$j" != "schema.json" ]]; then
+                check-jsonschema --verbose --schemafile schema.json $j
+              fi
+            done
+            cd ..
+          done
+          cd ..

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ flepimop/gempyor_pkg/.coverage
 
 # Environment variables
 .env
+
+# info/ directory
+info/**/*.json

--- a/flepimop/gempyor_pkg/pyproject.toml
+++ b/flepimop/gempyor_pkg/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "numpy",
     "pandas",
     "pyarrow",
+    "pydantic",
     "scipy",
     "seaborn",
     "sympy",

--- a/flepimop/gempyor_pkg/src/gempyor/info.py
+++ b/flepimop/gempyor_pkg/src/gempyor/info.py
@@ -1,3 +1,31 @@
+"""
+Retrieving static information from developer managed yaml files.
+
+Currently, it includes utilities for handling cluster-specific information, but it can 
+be extended to other categories as needed.
+
+Classes:
+    Module: Represents a software module with a name and optional version.
+    PathExport: Represents a path export with a path, prepend flag, and error handling.
+    Cluster: Represents a cluster with a name, list of modules, and list of path 
+        exports.
+
+Functions:
+    get_cluster_info: Retrieves cluster-specific information.
+
+Examples:
+    >>> from pprint import pprint
+    >>> from gempyor.info import get_cluster_info
+    >>> cluster_info = get_cluster_info("longleaf")
+    >>> cluster_info.name
+    'longleaf'
+    >>> pprint(cluster_info.modules)
+    [Module(name='gcc', version='9.1.0'),
+    Module(name='anaconda', version='2023.03'),
+    Module(name='git', version=None),
+    Module(name='aws', version=None)]
+"""
+
 __all__ = ["Cluster", "Module", "PathExport", "get_cluster_info"]
 
 
@@ -12,23 +40,55 @@ import yaml
 
 
 class Module(BaseModel):
+    """
+    A model representing a module to load.
+
+    Attributes:
+        name: The name of the module to load.
+        version: The specific version of the module to load if there is one.
+
+    See Also:
+        [Lmod](https://lmod.readthedocs.io/en/latest/)
+    """
+
     name: str
     version: str | None = None
 
 
 class PathExport(BaseModel):
+    """
+    A model representing the export path configuration.
+
+    Attributes:
+        path: The file system path of the path to add to the `$PATH` environment
+            variable.
+        prepend: A flag indicating whether to prepend additional information to the
+            `$PATH` environment variable.
+        error_if_missing: A flag indicating whether to raise an error if the path is
+            missing.
+    """
+
     path: Path
     prepend: bool = True
     error_if_missing: bool = False
 
 
 class Cluster(BaseModel):
+    """
+    A model representing a cluster configuration.
+
+    Attributes:
+        name: The name of the cluster.
+        modules: A list of modules associated with the cluster.
+        path_exports: A list of path exports for the cluster.
+    """
+
     name: str
     modules: list[Module] = []
     path_exports: list[PathExport] = []
 
 
-T = TypeVar("T", bound=BaseModel)
+_BASE_MODEL_TYPE = TypeVar("T", bound=BaseModel)
 
 
 _CLUSTER_FQDN_REGEXES: tuple[tuple[str, Pattern], ...] = (
@@ -38,8 +98,8 @@ _CLUSTER_FQDN_REGEXES: tuple[tuple[str, Pattern], ...] = (
 
 
 def _get_info(
-    category: str, name: str, model: type[T], flepi_path: os.PathLike | None
-) -> T:
+    category: str, name: str, model: type[_BASE_MODEL_TYPE], flepi_path: os.PathLike | None
+) -> _BASE_MODEL_TYPE:
     """
     Get and parse an information yaml file.
 
@@ -79,8 +139,14 @@ def get_cluster_info(name: str | None, flepi_path: os.PathLike | None = None) ->
         flepi_path: Either a path like determine the directory to look for the info
             directory in or `None` to use the `FLEPI_PATH` environment variable.
 
-    Returns
+    Returns:
         An object containing the information about the `name` cluster.
+
+    Examples:
+        >>> from gempyor.info import get_cluster_info
+        >>> cluster_info = get_cluster_info("longleaf")
+        >>> cluster_info.name
+        'longleaf'
     """
     name = _infer_cluster_from_fqdn() if name is None else name
     return _get_info("cluster", name, Cluster, flepi_path)

--- a/flepimop/gempyor_pkg/src/gempyor/info.py
+++ b/flepimop/gempyor_pkg/src/gempyor/info.py
@@ -13,10 +13,12 @@ class Module(BaseModel):
     name: str
     version: str | None = None
 
+
 class PathExport(BaseModel):
     path: Path
     prepend: bool = True
     error_if_missing: bool = False
+
 
 class Cluster(BaseModel):
     name: str

--- a/flepimop/gempyor_pkg/src/gempyor/info.py
+++ b/flepimop/gempyor_pkg/src/gempyor/info.py
@@ -1,0 +1,70 @@
+__all__ = ["Cluster", "Module", "get_cluster_info"]
+
+
+import os
+from pathlib import Path
+from typing import TypeVar
+
+from pydantic import BaseModel
+import yaml
+
+
+class Module(BaseModel):
+    name: str
+    version: str | None = None
+
+
+class Cluster(BaseModel):
+    name: str
+    modules: list[Module]
+
+
+T = TypeVar("T", bound=BaseModel)
+
+
+def _get_info(
+    category: str, name: str, model: type[T], flepi_path: os.PathLike | None
+) -> T:
+    """
+    Get and parse an information yaml file.
+
+    This function is a light wrapper around reading and parsing yaml files located in
+    `$FLEPI_PATH/info`.
+
+    Args:
+        category: The category of info to get, corresponds to a subdirectory in
+            `$FLEPI_PATH/info`.
+        name: The name of the info to get, corresponds to the name of a yaml file and
+            is usually a human readable short name.
+        model: The pydantic class to parse the info file with, determines the return
+            type.
+        flepi_path: Either a path like determine the directory to look for the info
+            directory in or `None` to use the `FLEPI_PATH` environment variable.
+
+    Returns:
+        An instance of `model` with the contained info found and parsed.
+    """
+    flepi_path = Path(os.getenv("FLEPI_PATH") if flepi_path is None else flepi_path)
+    info = flepi_path / "info" / category / f"{name}.yml"
+    if not info.exists() or not info.is_file():
+        raise ValueError(
+            f"Was expecting an information yaml at {info.absolute()}, "
+            "but either does not exist or is not a file."
+        )
+    return model.model_validate(yaml.safe_load(info.read_text()))
+
+
+def get_cluster_info(name: str, flepi_path: os.PathLike | None = None) -> Cluster:
+    """
+    Get cluster specific info.
+
+    Args:
+        name: The name of the cluster to pull information for. Currently only 'longleaf'
+            and 'rockfish' are supported.
+        flepi_path: Either a path like determine the directory to look for the info
+            directory in or `None` to use the `FLEPI_PATH` environment variable.
+
+    Returns
+        An object containing the information about the `name` cluster.
+    """
+    return _get_info("cluster", name, Cluster, flepi_path)

--- a/flepimop/gempyor_pkg/src/gempyor/info.py
+++ b/flepimop/gempyor_pkg/src/gempyor/info.py
@@ -1,4 +1,4 @@
-__all__ = ["Cluster", "Module", "get_cluster_info"]
+__all__ = ["Cluster", "Module", "PathExport", "get_cluster_info"]
 
 
 import os
@@ -13,10 +13,15 @@ class Module(BaseModel):
     name: str
     version: str | None = None
 
+class PathExport(BaseModel):
+    path: Path
+    prepend: bool = True
+    error_if_missing: bool = False
 
 class Cluster(BaseModel):
     name: str
-    modules: list[Module]
+    modules: list[Module] = []
+    path_exports: list[PathExport] = []
 
 
 T = TypeVar("T", bound=BaseModel)

--- a/flepimop/gempyor_pkg/src/gempyor/info.py
+++ b/flepimop/gempyor_pkg/src/gempyor/info.py
@@ -3,7 +3,9 @@ __all__ = ["Cluster", "Module", "PathExport", "get_cluster_info"]
 
 import os
 from pathlib import Path
-from typing import TypeVar
+import re
+from socket import getfqdn
+from typing import Pattern, TypeVar
 
 from pydantic import BaseModel
 import yaml
@@ -27,6 +29,12 @@ class Cluster(BaseModel):
 
 
 T = TypeVar("T", bound=BaseModel)
+
+
+_CLUSTER_FQDN_REGEXES: tuple[tuple[str, Pattern], ...] = (
+    ("longleaf", re.compile(r"^longleaf\-login[0-9]+\.its\.unc\.edu$")),
+    ("rockfish", re.compile(r"^login[0-9]+\.cm\.cluster$")),
+)
 
 
 def _get_info(
@@ -61,17 +69,35 @@ def _get_info(
     return model.model_validate(yaml.safe_load(info.read_text()))
 
 
-def get_cluster_info(name: str, flepi_path: os.PathLike | None = None) -> Cluster:
+def get_cluster_info(name: str | None, flepi_path: os.PathLike | None = None) -> Cluster:
     """
     Get cluster specific info.
 
     Args:
         name: The name of the cluster to pull information for. Currently only 'longleaf'
-            and 'rockfish' are supported.
+            and 'rockfish' are supported or `None` to infer from the FQDN.
         flepi_path: Either a path like determine the directory to look for the info
             directory in or `None` to use the `FLEPI_PATH` environment variable.
 
     Returns
         An object containing the information about the `name` cluster.
     """
+    name = _infer_cluster_from_fqdn() if name is None else name
     return _get_info("cluster", name, Cluster, flepi_path)
+
+
+def _infer_cluster_from_fqdn() -> str:
+    """
+    Infer the cluster name from the FQDN.
+
+    Returns:
+        The name of the cluster inferred from the FQDN.
+
+    Raises:
+        ValueError: If the value of `socket.getfqdn()` does not match an expected regex.
+    """
+    fqdn = getfqdn()
+    for cluster, regex in _CLUSTER_FQDN_REGEXES:
+        if regex.match(fqdn):
+            return cluster
+    raise ValueError(f"The fqdn, '{fqdn}', does not match any of the expected clusters.")

--- a/flepimop/gempyor_pkg/src/gempyor/info.py
+++ b/flepimop/gempyor_pkg/src/gempyor/info.py
@@ -152,18 +152,27 @@ def get_cluster_info(name: str | None, flepi_path: os.PathLike | None = None) ->
     return _get_info("cluster", name, Cluster, flepi_path)
 
 
-def _infer_cluster_from_fqdn() -> str:
+def _infer_cluster_from_fqdn(raise_error: bool = True) -> str | None:
     """
     Infer the cluster name from the FQDN.
+
+    Args:
+        raise_error: A flag indicating whether to raise an error if the FQDN does not
+            match any of the expected regexes.
 
     Returns:
         The name of the cluster inferred from the FQDN.
 
     Raises:
-        ValueError: If the value of `socket.getfqdn()` does not match an expected regex.
+        ValueError: If the value of `socket.getfqdn()` does not match an expected regex
+            and `raise_error` is `True`.
     """
     fqdn = getfqdn()
     for cluster, regex in _CLUSTER_FQDN_REGEXES:
         if regex.match(fqdn):
             return cluster
-    raise ValueError(f"The fqdn, '{fqdn}', does not match any of the expected clusters.")
+    if raise_error:
+        raise ValueError(
+            f"The fqdn, '{fqdn}', does not match any of the expected clusters."
+        )
+    return None

--- a/flepimop/gempyor_pkg/tests/info/test__get_info.py
+++ b/flepimop/gempyor_pkg/tests/info/test__get_info.py
@@ -1,0 +1,56 @@
+from pathlib import Path
+
+from pydantic import BaseModel
+import pytest
+import yaml
+
+from gempyor.info import _get_info
+
+
+class NameOnly(BaseModel):
+    name: str
+
+
+@pytest.fixture
+def create_mock_info_directory(tmp_path: Path) -> Path:
+    for file, contents in (
+        ("abc/def.yml", {"name": "Foobar"}),
+        ("abc/ghi.yml", {"name": "Fizzbuzz"}),
+    ):
+        file = tmp_path / "info" / file
+        file.parent.mkdir(parents=True, exist_ok=True)
+        with file.open(mode="w") as f:
+            yaml.dump(contents, f)
+    return tmp_path.absolute()
+
+
+def test_file_does_not_exist_value_error(
+    monkeypatch: pytest.MonkeyPatch, create_mock_info_directory: Path
+) -> None:
+    monkeypatch.setenv("FLEPI_PATH", str(create_mock_info_directory.parent))
+    with pytest.raises(ValueError):
+        _get_info("does_not", "exist", object, None)
+
+
+@pytest.mark.parametrize(
+    ("category", "name", "model"), (("abc", "def", NameOnly), ("abc", "ghi", NameOnly))
+)
+def test_output_validation(
+    monkeypatch: pytest.MonkeyPatch,
+    create_mock_info_directory: Path,
+    category: str,
+    name: str,
+    model: type[BaseModel],
+) -> None:
+    monkeypatch.setenv("FLEPI_PATH", str(create_mock_info_directory))
+    results = []
+    for flepi_path in (
+        None,
+        create_mock_info_directory,
+        str(create_mock_info_directory),
+    ):
+        info = _get_info(category, name, model, flepi_path)
+        assert isinstance(info, model)
+        results.append(info)
+    for i in range(len(results) - 1):
+        assert results[i] == results[i + 1]

--- a/flepimop/gempyor_pkg/tests/info/test__infer_cluster_from_fqdn.py
+++ b/flepimop/gempyor_pkg/tests/info/test__infer_cluster_from_fqdn.py
@@ -20,18 +20,27 @@ def test_no_matching_fqdn_found_value_error(fqdn: str) -> None:
 
 
 @pytest.mark.parametrize(
-    ("fqdn", "expected"),
+    ("fqdn", "raise_error", "expected"),
     (
-        ("login01.cm.cluster", "rockfish"),
-        ("login3.cm.cluster", "rockfish"),
-        ("longleaf-login1.its.unc.edu", "longleaf"),
-        ("longleaf-login07.its.unc.edu", "longleaf"),
+        ("login01.cm.cluster", True, "rockfish"),
+        ("login01.cm.cluster", False, "rockfish"),
+        ("login3.cm.cluster", True, "rockfish"),
+        ("login3.cm.cluster", False, "rockfish"),
+        ("longleaf-login1.its.unc.edu", True, "longleaf"),
+        ("longleaf-login1.its.unc.edu", False, "longleaf"),
+        ("longleaf-login07.its.unc.edu", True, "longleaf"),
+        ("longleaf-login07.its.unc.edu", False, "longleaf"),
+        ("longleaf-login07.its.unc.edu", True, "longleaf"),
+        ("longleaf-login07.its.unc.edu", False, "longleaf"),
+        ("epid-iss-MacBook-Pro.local", False, None),
     ),
 )
-def test_exact_results_for_select_values(fqdn: str, expected: str) -> None:
+def test_exact_results_for_select_values(
+    fqdn: str, raise_error: bool, expected: str
+) -> None:
     def socket_fqdn_wraps() -> str:
         return fqdn
 
     with patch("gempyor.info.getfqdn", wraps=socket_fqdn_wraps) as socket_fqdn_patch:
-        assert _infer_cluster_from_fqdn() == expected
+        assert _infer_cluster_from_fqdn(raise_error=raise_error) == expected
         socket_fqdn_patch.assert_called_once()

--- a/flepimop/gempyor_pkg/tests/info/test__infer_cluster_from_fqdn.py
+++ b/flepimop/gempyor_pkg/tests/info/test__infer_cluster_from_fqdn.py
@@ -1,0 +1,37 @@
+from unittest.mock import patch
+
+import pytest
+
+from gempyor.info import _infer_cluster_from_fqdn
+
+
+@pytest.mark.parametrize("fqdn", ("new.cluster.com", "unsupported.cluster"))
+def test_no_matching_fqdn_found_value_error(fqdn: str) -> None:
+    def socket_fqdn_wraps() -> str:
+        return fqdn
+
+    with patch("gempyor.info.getfqdn", wraps=socket_fqdn_wraps) as socket_fqdn_patch:
+        with pytest.raises(
+            ValueError,
+            match=f"^The fqdn, '{fqdn}', does not match any of the expected clusters.$",
+        ):
+            _infer_cluster_from_fqdn()
+        socket_fqdn_patch.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("fqdn", "expected"),
+    (
+        ("login01.cm.cluster", "rockfish"),
+        ("login3.cm.cluster", "rockfish"),
+        ("longleaf-login1.its.unc.edu", "longleaf"),
+        ("longleaf-login07.its.unc.edu", "longleaf"),
+    ),
+)
+def test_exact_results_for_select_values(fqdn: str, expected: str) -> None:
+    def socket_fqdn_wraps() -> str:
+        return fqdn
+
+    with patch("gempyor.info.getfqdn", wraps=socket_fqdn_wraps) as socket_fqdn_patch:
+        assert _infer_cluster_from_fqdn() == expected
+        socket_fqdn_patch.assert_called_once()

--- a/flepimop/gempyor_pkg/tests/info/test_get_cluster_info.py
+++ b/flepimop/gempyor_pkg/tests/info/test_get_cluster_info.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import patch
 
 import pytest
 
@@ -10,6 +11,23 @@ from gempyor.info import Cluster, get_cluster_info
     os.getenv("FLEPI_PATH") is None,
     reason="The $FLEPI_PATH environment variable is not set.",
 )
-def test_output_validation(name: str) -> None:
+def test_exact_results_given_cluster_name(name: str) -> None:
     cluster = get_cluster_info(name)
     assert isinstance(cluster, Cluster)
+
+
+@pytest.mark.parametrize("name", ("longleaf", "rockfish"))
+@pytest.mark.skipif(
+    os.getenv("FLEPI_PATH") is None,
+    reason="The $FLEPI_PATH environment variable is not set.",
+)
+def test_exact_results_when_inferred_from_fqdn(name: str) -> None:
+    def infer_cluster_from_fqdn_wraps() -> str:
+        return name
+
+    with patch(
+        "gempyor.info._infer_cluster_from_fqdn", wraps=infer_cluster_from_fqdn_wraps
+    ) as infer_cluster_from_fqdn_patch:
+        cluster = get_cluster_info(None)
+        assert isinstance(cluster, Cluster)
+        infer_cluster_from_fqdn_patch.assert_called_once()

--- a/flepimop/gempyor_pkg/tests/info/test_get_cluster_info.py
+++ b/flepimop/gempyor_pkg/tests/info/test_get_cluster_info.py
@@ -1,0 +1,15 @@
+import os
+
+import pytest
+
+from gempyor.info import Cluster, get_cluster_info
+
+
+@pytest.mark.parametrize("name", ("longleaf", "rockfish"))
+@pytest.mark.skipif(
+    os.getenv("FLEPI_PATH") is None,
+    reason="The $FLEPI_PATH environment variable is not set.",
+)
+def test_output_validation(name: str) -> None:
+    cluster = get_cluster_info(name)
+    assert isinstance(cluster, Cluster)

--- a/info/cluster/longleaf.yml
+++ b/info/cluster/longleaf.yml
@@ -5,3 +5,4 @@ modules:
   - name: anaconda
     version: "2023.03"
   - name: git
+  - name: aws

--- a/info/cluster/longleaf.yml
+++ b/info/cluster/longleaf.yml
@@ -1,0 +1,7 @@
+name: longleaf
+modules:
+  - name: gcc
+    version: 9.1.0
+  - name: anaconda
+    version: "2023.03"
+  - name: git

--- a/info/cluster/rockfish.yml
+++ b/info/cluster/rockfish.yml
@@ -1,0 +1,9 @@
+name: rockfish
+modules:
+  - name: gcc
+    version: 9.3.0
+  - name: anaconda
+    version: "2020.07"
+  - name: git
+    version: 2.42.0
+  - name: slurm

--- a/info/cluster/rockfish.yml
+++ b/info/cluster/rockfish.yml
@@ -7,3 +7,5 @@ modules:
   - name: git
     version: 2.42.0
   - name: slurm
+path_exports:
+  - path: ~/aws-cli/bin

--- a/info/cluster/schema.yml
+++ b/info/cluster/schema.yml
@@ -23,3 +23,20 @@ properties:
         version:
           description: The preferred version of the module if there is one.
           type: string
+  path_exports:
+    description: Modifications to the $PATH environment variable in cluster setup.
+    type: array
+    items:
+      type: object
+      required:
+        - path
+      properties:
+        path:
+          description: The path to add to the $PATH environment variable.
+          type: string
+        prepend:
+          description: If true the path will prepended and appended if false.
+          type: boolean
+        error_if_missing:
+          description: If true an error will be thrown if the path is missing and if false will be ignored if missing.
+          type: boolean

--- a/info/cluster/schema.yml
+++ b/info/cluster/schema.yml
@@ -1,5 +1,4 @@
 $schema: https://json-schema.org/draft/2020-12/schema
-$id: https://example.com/product.schema.json
 title: Cluster
 description: A generic description of an HPC cluster and its properties.
 type: object

--- a/info/cluster/schema.yml
+++ b/info/cluster/schema.yml
@@ -1,0 +1,25 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+$id: https://example.com/product.schema.json
+title: Cluster
+description: A generic description of an HPC cluster and its properties.
+type: object
+required:
+  - name
+properties:
+  name:
+    description: A short hand human readable unique name.
+    type: string
+  modules:
+    description: The modules to load when setting up this cluster.
+    type: array
+    items:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          description: The name of the module.
+          type: string
+        version:
+          description: The preferred version of the module if there is one.
+          type: string


### PR DESCRIPTION
### Describe your changes.

This pull request adds an `info` module to `gempyor` with:

- Internal `_get_info` helper for pulling a configuration YAML given a category and class to parse into,
- Public `get_cluster_info` for pulling the configuration associated with a particular HPC cluster, and
- Internal `_infer_cluster_from_fqdn` to guess the HPC cluster from the FQDN.

New module/functionality include docstrings and unit tests. This PR also makes it easy to add future categories of generic info/config as needed. 

### Does this pull request make any user interface changes? If so please describe.

The user interface changes are contained in `gempyor.info` and only contains new functionality, no breaking changes.

Those are reflected in updates to the documentation in docstrings, but could be added to the GitBook if needed. However I think the docstrings are comprehensive and are useful for the target audience.

### What does your pull request address? Tag relevant issues.

This pull request addresses GH-342, and was spun out of GH-394.
