### PR TITLE
Fix `inference CI` Triggers

### DIFF
--- a/.github/workflows/flepicommon-ci.yml
+++ b/.github/workflows/flepicommon-ci.yml
@@ -56,6 +56,10 @@ jobs:
         with:
           key: flepicommon-rlibs-${{ runner.os }}-${{ matrix.R-version }}-${{ hashFiles('flepimop/R_packages/flepicommon/DESCRIPTION', 'flepimop/R_packages/flepicommon/NAMESPACE') }}-${{ env.R_LIBPATH_CKSUM }}-${{ env.CACHE_DATE }}
           path: ${{ env.R_LIBPATH }}
+          restore-keys: |
+            flepicommon-rlibs-${{ runner.os }}-${{ matrix.R-version }}-${{ hashFiles('flepimop/R_packages/flepicommon/DESCRIPTION', 'flepimop/R_packages/flepicommon/NAMESPACE') }}-${{ env.R_LIBPATH_CKSUM }}-
+            flepicommon-rlibs-${{ runner.os }}-${{ matrix.R-version }}-${{ hashFiles('flepimop/R_packages/flepicommon/DESCRIPTION', 'flepimop/R_packages/flepicommon/NAMESPACE') }}-
+            flepicommon-rlibs-${{ runner.os }}-${{ matrix.R-version }}-
       - name: Install R Dependencies
         if: steps.r-library-cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/inference-ci.yml
+++ b/.github/workflows/inference-ci.yml
@@ -72,6 +72,13 @@ jobs:
         with:
           key: inference-rlibs-${{ runner.os }}-${{ matrix.R-version }}-${{ hashFiles('flepimop/R_packages/flepicommon/DESCRIPTION', 'flepimop/R_packages/flepicommon/NAMESPACE', 'flepimop/R_packages/inference/DESCRIPTION', 'flepimop/R_packages/inference/NAMESPACE') }}-${{ env.R_LIBPATH_CKSUM }}-${{ env.CACHE_DATE }}
           path: ${{ env.R_LIBPATH }}
+          restore-keys: |
+            inference-rlibs-${{ runner.os }}-${{ matrix.R-version }}-${{ hashFiles('flepimop/R_packages/flepicommon/DESCRIPTION', 'flepimop/R_packages/flepicommon/NAMESPACE', 'flepimop/R_packages/inference/DESCRIPTION', 'flepimop/R_packages/inference/NAMESPACE') }}-${{ env.R_LIBPATH_CKSUM }}-
+            inference-rlibs-${{ runner.os }}-${{ matrix.R-version }}-${{ hashFiles('flepimop/R_packages/flepicommon/DESCRIPTION', 'flepimop/R_packages/flepicommon/NAMESPACE', 'flepimop/R_packages/inference/DESCRIPTION', 'flepimop/R_packages/inference/NAMESPACE') }}-
+            inference-rlibs-${{ runner.os }}-${{ matrix.R-version }}-
+            flepicommon-rlibs-${{ runner.os }}-${{ matrix.R-version }}-${{ hashFiles('flepimop/R_packages/flepicommon/DESCRIPTION', 'flepimop/R_packages/flepicommon/NAMESPACE') }}-${{ env.R_LIBPATH_CKSUM }}-
+            flepicommon-rlibs-${{ runner.os }}-${{ matrix.R-version }}-${{ hashFiles('flepimop/R_packages/flepicommon/DESCRIPTION', 'flepimop/R_packages/flepicommon/NAMESPACE') }}-
+            flepicommon-rlibs-${{ runner.os }}-${{ matrix.R-version }}-
       - name: Install R Dependencies For flepicommon
         if: steps.r-library-cache.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION
### Describe your changes.

This pull request:

1. Fixes GH-411 by triggering the `inference CI` action on expanded set of file changes, and
2. Adds restore keys to the R lib caching to allow caches to be pulled from prior weeks for PRs that span a while.

### Does this pull request make any user interface changes? If so please describe.

The user interface changes are in PRs, users will now notice the `inference CI` action run when editing `gempyor` or `flepicommon`. The GitHub actions we use aren't documented anywhere that I know of, perhaps they should be added to the GitBook here: https://iddynamics.gitbook.io/flepimop/development/git-and-github-usage?

### What does your pull request address? Tag relevant issues.

This pull request addresses GH-411.