### PR TITLE
`gempyor` API docstring refurbishment

### DIFF
--- a/flepimop/gempyor_pkg/src/gempyor/calibrate.py
+++ b/flepimop/gempyor_pkg/src/gempyor/calibrate.py
@@ -121,7 +121,7 @@ os.environ["OMP_NUM_THREADS"] = "1"
 # @profile_options
 # @profile()
 def calibrate(
-    config_filepath: str,
+    config_filepath: str | pathlib.Path,
     project_path: str,
     nwalkers: int,
     niter: int,

--- a/flepimop/gempyor_pkg/src/gempyor/calibrate.py
+++ b/flepimop/gempyor_pkg/src/gempyor/calibrate.py
@@ -150,7 +150,7 @@ def calibrate(
     resume_location: str,
 ) -> None:
     """
-    Calibrate using an `emcee` sampler to initialize a model based on a config. 
+    Calibrate using an `emcee` sampler to initialize a model based on a config.
 
     Args:
         config_filepath: Path to the configuration file.
@@ -158,13 +158,13 @@ def calibrate(
         nwalkers: Number of walkers (MCMC chains) to run.
         niter: Number of MCMC iterations to perform.
         nsamples: Number of samples to select from final MCMC chain.
-        nthin (optional): How often to save samples. 
+        nthin (optional): How often to save samples.
         ncpu: Number of CPU cores to use for parallelization.
         input_run_id (optional): Run ID. Will be auto-generated if not provdied.
         prefix (optional): A prefix for output files.
         resume: Whether or not to resume a previous calibration run.
         resume_location (optional): Path to the location of the saved state to resume from.
-    
+
     Returns:
         None
     """

--- a/flepimop/gempyor_pkg/src/gempyor/calibrate.py
+++ b/flepimop/gempyor_pkg/src/gempyor/calibrate.py
@@ -1,6 +1,7 @@
 """
 Facilitates the calibration of the model using the `emcee` MCMC sampler. 
-Provides CLI options for users to specify simulation paramters. 
+
+Provides CLI options for users to specify simulation parameters. 
 
 Functions:
     calibrate: Reads a configuration file for simulation settings.

--- a/flepimop/gempyor_pkg/src/gempyor/calibrate.py
+++ b/flepimop/gempyor_pkg/src/gempyor/calibrate.py
@@ -1,24 +1,9 @@
 """
-calibrate.py
-
 Facilitates the calibration of the model using the `emcee` MCMC sampler. 
 Provides CLI options for users to specify simulation paramters. 
 
 Functions:
     calibrate: Reads a configuration file for simulation settings.
-
-Options:
-   --config, -c             Path to the configuration file. 
-   --project_path, -p       Path to the flepiMoP project directory.  
-   --nwalkers, -n           Number of walkers (MCMC chains) to use. Overrides value in config.
-   --niterations            Number of MCMC iterations. Overrides value in config.
-   --nsamples               Number of samples to retain. OVerrides value in config.
-   --nthin                  Number of samples to thin. Overrides value in config.
-   --j, --jobs              Number of CPU cores to use for prallelization.
-   --id                     Unique ID for the run. 
-   --prefix                 Prefix for output files.
-   --resume                 Flag determining whether or not to resume the current calibration.
-   --resume_location, -r    Path to the location to resume the run from.
 
 """
 
@@ -142,12 +127,12 @@ def calibrate(
     nwalkers: int,
     niter: int,
     nsamples: int,
-    nthin: int,
+    nthin: int | None,
     ncpu: int,
-    input_run_id: int,
-    prefix: str,
+    input_run_id: int | None,
+    prefix: str | None,
     resume: bool,
-    resume_location: str,
+    resume_location: str | None,
 ) -> None:
     """
     Calibrate using an `emcee` sampler to initialize a model based on a config.
@@ -158,12 +143,12 @@ def calibrate(
         nwalkers: Number of walkers (MCMC chains) to run.
         niter: Number of MCMC iterations to perform.
         nsamples: Number of samples to select from final MCMC chain.
-        nthin (optional): How often to save samples.
+        nthin: How often to save samples.
         ncpu: Number of CPU cores to use for parallelization.
-        input_run_id (optional): Run ID. Will be auto-generated if not provdied.
-        prefix (optional): A prefix for output files.
+        input_run_id: Run ID. Will be auto-generated if not provdied.
+        prefix: A prefix for output files.
         resume: Whether or not to resume a previous calibration run.
-        resume_location (optional): Path to the location of the saved state to resume from.
+        resume_location: Path to the location of the saved state to resume from.
 
     Returns:
         None

--- a/flepimop/gempyor_pkg/src/gempyor/calibrate.py
+++ b/flepimop/gempyor_pkg/src/gempyor/calibrate.py
@@ -1,3 +1,27 @@
+"""
+calibrate.py
+
+Facilitates the calibration of the model using the `emcee` MCMC sampler. 
+Provides CLI options for users to specify simulation paramters. 
+
+Functions:
+    calibrate: Reads a configuration file for simulation settings.
+
+Options:
+   --config, -c             Path to the configuration file. 
+   --project_path, -p       Path to the flepiMoP project directory.  
+   --nwalkers, -n           Number of walkers (MCMC chains) to use. Overrides value in config.
+   --niterations            Number of MCMC iterations. Overrides value in config.
+   --nsamples               Number of samples to retain. OVerrides value in config.
+   --nthin                  Number of samples to thin. Overrides value in config.
+   --j, --jobs              Number of CPU cores to use for prallelization.
+   --id                     Unique ID for the run. 
+   --prefix                 Prefix for output files.
+   --resume                 Flag determining whether or not to resume the current calibration.
+   --resume_location, -r    Path to the location to resume the run from.
+
+"""
+
 #!/usr/bin/env python
 import click
 from gempyor import model_info, file_paths, config, inference_parameter
@@ -113,18 +137,37 @@ os.environ["OMP_NUM_THREADS"] = "1"
 # @profile_options
 # @profile()
 def calibrate(
-    config_filepath,
-    project_path,
-    nwalkers,
-    niter,
-    nsamples,
-    nthin,
-    ncpu,
-    input_run_id,
-    prefix,
-    resume,
-    resume_location,
-):
+    config_filepath: str,
+    project_path: str,
+    nwalkers: int,
+    niter: int,
+    nsamples: int,
+    nthin: int,
+    ncpu: int,
+    input_run_id: int,
+    prefix: str,
+    resume: bool,
+    resume_location: str,
+) -> None:
+    """
+    Calibrate using an `emcee` sampler to initialize a model based on a config. 
+
+    Args:
+        config_filepath: Path to the configuration file.
+        project_path: Path to the project directory.
+        nwalkers: Number of walkers (MCMC chains) to run.
+        niter: Number of MCMC iterations to perform.
+        nsamples: Number of samples to select from final MCMC chain.
+        nthin (optional): How often to save samples. 
+        ncpu: Number of CPU cores to use for parallelization.
+        input_run_id (optional): Run ID. Will be auto-generated if not provdied.
+        prefix (optional): A prefix for output files.
+        resume: Whether or not to resume a previous calibration run.
+        resume_location (optional): Path to the location of the saved state to resume from.
+    
+    Returns:
+        None
+    """
     # Choose a run_id
     if input_run_id is None:
         base_run_id = pathlib.Path(config_filepath).stem.replace("config_", "")

--- a/flepimop/gempyor_pkg/src/gempyor/calibrate.py
+++ b/flepimop/gempyor_pkg/src/gempyor/calibrate.py
@@ -4,7 +4,6 @@ Provides CLI options for users to specify simulation paramters.
 
 Functions:
     calibrate: Reads a configuration file for simulation settings.
-
 """
 
 #!/usr/bin/env python
@@ -136,22 +135,6 @@ def calibrate(
 ) -> None:
     """
     Calibrate using an `emcee` sampler to initialize a model based on a config.
-
-    Args:
-        config_filepath: Path to the configuration file.
-        project_path: Path to the project directory.
-        nwalkers: Number of walkers (MCMC chains) to run.
-        niter: Number of MCMC iterations to perform.
-        nsamples: Number of samples to select from final MCMC chain.
-        nthin: How often to save samples.
-        ncpu: Number of CPU cores to use for parallelization.
-        input_run_id: Run ID. Will be auto-generated if not provdied.
-        prefix: A prefix for output files.
-        resume: Whether or not to resume a previous calibration run.
-        resume_location: Path to the location of the saved state to resume from.
-
-    Returns:
-        None
     """
     # Choose a run_id
     if input_run_id is None:

--- a/flepimop/gempyor_pkg/src/gempyor/calibrate.py
+++ b/flepimop/gempyor_pkg/src/gempyor/calibrate.py
@@ -8,17 +8,22 @@ Functions:
 """
 
 #!/usr/bin/env python
+import os
+import shutil
+import copy
+import pathlib
+import multiprocessing
+
 import click
+import emcee
+import numpy as np
+
+import gempyor
 from gempyor import model_info, file_paths, config, inference_parameter
 from gempyor.inference import GempyorInference
 from gempyor.utils import config, as_list
-import gempyor
-import numpy as np
-import os, shutil, copy
-import emcee
-import pathlib
-import multiprocessing
 import gempyor.postprocess_inference
+
 
 # from .profile import profile_options
 

--- a/flepimop/gempyor_pkg/src/gempyor/cli.py
+++ b/flepimop/gempyor_pkg/src/gempyor/cli.py
@@ -28,6 +28,8 @@ from .NPI import base
 @click.pass_context
 def patch(ctx: click.Context = mock_context, **kwargs) -> None:
     """
+    Merge configuration files.
+
     This command will merge multiple config files together by overriding the top level
     keys in config files. The order of the config files is important, as the last file
     has the highest priority and the first has the lowest.

--- a/flepimop/gempyor_pkg/src/gempyor/cli.py
+++ b/flepimop/gempyor_pkg/src/gempyor/cli.py
@@ -27,8 +27,7 @@ from .NPI import base
 )
 @click.pass_context
 def patch(ctx: click.Context = mock_context, **kwargs) -> None:
-    """Merge configuration files
-
+    """
     This command will merge multiple config files together by overriding the top level
     keys in config files. The order of the config files is important, as the last file
     has the highest priority and the first has the lowest.

--- a/flepimop/gempyor_pkg/src/gempyor/compartments.py
+++ b/flepimop/gempyor_pkg/src/gempyor/compartments.py
@@ -15,6 +15,7 @@ Functions:
     plot: Generate a plot representing transition between compartments. 
     export: Export compartment data to a CSV file. 
 """
+
 from functools import reduce
 
 import numpy as np
@@ -33,10 +34,10 @@ logger = logging.getLogger(__name__)
 
 class Compartments:
     """
-    An object to handle compartment data for the model. 
+    An object to handle compartment data for the model.
 
     Arguments:
-        seir_config (optional): Config file for SEIR model construction information. 
+        seir_config (optional): Config file for SEIR model construction information.
         compartments_config (optional): Config file for compartment information.
         compartments_file (optional): File to specify compartment information.
         transitions_file (optional): File to specify transition information.
@@ -44,13 +45,14 @@ class Compartments:
     Attributes:
         times_set: Counter to track succesful data intialization from config.
     """
+
     # Minimal object to be easily picklable for // runs
     def __init__(
         self,
-        seir_config = None,
-        compartments_config = None,
-        compartments_file = None,
-        transitions_file = None,
+        seir_config=None,
+        compartments_config=None,
+        compartments_file=None,
+        transitions_file=None,
     ):
         self.times_set = 0
 
@@ -70,7 +72,7 @@ class Compartments:
         """
         This method is called by the constructor if the compartments are not loaded from a file.
         It will parse the compartments and transitions from the configuration files.
-        It will populate dynamic class attributes `self.compartments` and `self.transitions`. 
+        It will populate dynamic class attributes `self.compartments` and `self.transitions`.
         """
         self.compartments = self.parse_compartments(seir_config, compartment_config)
         self.transitions = self.parse_transitions(seir_config, False)
@@ -89,7 +91,7 @@ class Compartments:
             compartment_config: Configuration information for model comartments.
 
         Returns:
-            A DataFrame where each row is a unique compartment and columns 
+            A DataFrame where each row is a unique compartment and columns
             correspond to attributes of the compartments.
         """
         compartment_df = None
@@ -105,13 +107,15 @@ class Compartments:
         )
         return compartment_df
 
-    def parse_transitions(self, seir_config: dict, fake_config: bool = False) -> pd.DataFrame:
+    def parse_transitions(
+        self, seir_config: dict, fake_config: bool = False
+    ) -> pd.DataFrame:
         """
         Parses the transitions defined in config and returns a concatenated DataFrame.
 
         Args:
             seir_config: Configuraton information for model.
-            fake_config (optional): 
+            fake_config (optional):
                 Flag indicating whether or not transitions provied are placeholders.
                 Default value is False.
         Returns:
@@ -503,18 +507,18 @@ class Compartments:
         """
         Return the index of a compartiment given a filter. The filter has to isolate a compartiment,
         but it ignore columns that don't exist:
-        
+
         Args:
-            comp_dict: 
-                A dictionary where keys are compartment names and 
+            comp_dict:
+                A dictionary where keys are compartment names and
                 values are values to filter by for each column.
-            error_info (optional): 
-                A message providing additional context about where the 
-                the method was called from. Default value is "no information". 
-        
+            error_info (optional):
+                A message providing additional context about where the
+                the method was called from. Default value is "no information".
+
         Returns:
             Index of the comaprtment that matches the filter.
-        
+
         Raises:
             ValueError: Filter results in more than one or zero matches.
         """
@@ -535,14 +539,14 @@ class Compartments:
 
     def get_transition_array(self) -> tuple:
         """
-        Constructs the transition matrix for the model. 
+        Constructs the transition matrix for the model.
 
         Returns:
             tuple:
                 - a list of unique strings from `proportion_exponent` and `rate`
                 - array representing transitions and corresponding compartment indices.
                 - array representing proportion compartment indices
-                - array containing start and end indices for proportions 
+                - array containing start and end indices for proportions
 
         Raises:
             ValueError: If term is not found in list of valid compartments.
@@ -708,17 +712,19 @@ class Compartments:
             proportion_info,
         )
 
-    def parse_parameters(self, parameters: list, parameter_names: list, unique_strings: list) -> np.ndarray:
+    def parse_parameters(
+        self, parameters: list, parameter_names: list, unique_strings: list
+    ) -> np.ndarray:
         """
         Parses provided parameters and stores them in NumPy arrays.
 
         Args:
             parameters: Input parameters to be parsed.
             parameter_names: List of all parameter names.
-            unique_strings: 
-                List of unique values from `proportion_exponent` 
+            unique_strings:
+                List of unique values from `proportion_exponent`
                 and `rate` columns of transitions data.
-        
+
         Returns:
             Array of parsed parameters.
         """
@@ -850,7 +856,7 @@ class Compartments:
     def get_compartments_explicitDF(self) -> pd.DataFrame:
         """
         Returns a copy of the compartments information DataFrame.
-        All columns receive a 'mc_' prefix.  
+        All columns receive a 'mc_' prefix.
 
         Returns:
             A copy of the compartments DataFrame.
@@ -916,11 +922,11 @@ class Compartments:
 
 def get_list_dimension(thing: any) -> int:
     """
-    Returns the dimension of a given object. 
-    
+    Returns the dimension of a given object.
+
     Args:
         thing: Object whose dimension needs to be determined.
-    
+
     Returns:
         int: Length of the object if a list, otherwise 1.
     """
@@ -929,19 +935,21 @@ def get_list_dimension(thing: any) -> int:
     return 1
 
 
-def list_access_element_safe(thing: any, idx: int, dimension=None, encapsulate_as_list=False) -> Union[any, list]:
+def list_access_element_safe(
+    thing: any, idx: int, dimension=None, encapsulate_as_list=False
+) -> Union[any, list]:
     """
     Attempts to access an element from the given object `thing` at the specified index `idx`.
-    
+
     Args:
         thing: Object to be accessed from.
-        idx: Index of object you would like to access. 
+        idx: Index of object you would like to access.
         dimension (optional): Dimension or shape of the object.
         encapsulate_as_list (optional): If `True`, the accessed element will be returned as a list.
-    
+
     Raises:
         Exception: If `thing` is not iterable or `idx ` is out of range.
-    
+
     Returns:
         Item at `idx` if `thing` is list, or
         element itself if `thing` is not a list.
@@ -959,12 +967,14 @@ def list_access_element_safe(thing: any, idx: int, dimension=None, encapsulate_a
         )
 
 
-def list_access_element(thing: any, idx: int, dimension=None, encapsulate_as_list=False) -> Union[any, list]:
+def list_access_element(
+    thing: any, idx: int, dimension=None, encapsulate_as_list=False
+) -> Union[any, list]:
     """
     Access an element from a list or return the input itself if not a list.
     If input `thing` is a list, the function will return the element at the specified index (`idx`).
-    If input `thing` is not a list, the function will return the element itself, regardless of the 
-    `idx` value. 
+    If input `thing` is not a list, the function will return the element itself, regardless of the
+    `idx` value.
 
     Args:
 
@@ -990,14 +1000,14 @@ def list_access_element(thing: any, idx: int, dimension=None, encapsulate_as_lis
 
 def list_recursive_convert_to_string(thing: any) -> str:
     """
-    Return given object as a str, 
+    Return given object as a str,
     or recursively convert elements of given list to strs.
 
     Args:
         thing: Object to be converted to a str or series of strs.
-    
+
     Returns:
-        Value(s) in `thing` as str(s). 
+        Value(s) in `thing` as str(s).
     """
     if type(thing) == list:
         return [list_recursive_convert_to_string(x) for x in thing]
@@ -1009,8 +1019,8 @@ def list_recursive_convert_to_string(thing: any) -> str:
 def compartments(ctx: Context):
     """
     Add commands for working with FlepiMoP compartments.
-    A container for subcommands `plot` and `export`. 
-    Commands in this container will require context about the compartmental model. 
+    A container for subcommands `plot` and `export`.
+    Commands in this container will require context about the compartmental model.
     """
     pass
 

--- a/flepimop/gempyor_pkg/src/gempyor/compartments.py
+++ b/flepimop/gempyor_pkg/src/gempyor/compartments.py
@@ -73,7 +73,7 @@ class Compartments:
         """
         This method is called by the constructor if the compartments are not loaded from a file.
         It will parse the compartments and transitions from the configuration files.
-        It will populate dynamic class attributes `self.compartments` and `self.transitions`.
+        It will populate dynamic class attributes `compartments` and `transitions`.
         """
         self.compartments = self.parse_compartments(seir_config, compartment_config)
         self.transitions = self.parse_transitions(seir_config, False)

--- a/flepimop/gempyor_pkg/src/gempyor/compartments.py
+++ b/flepimop/gempyor_pkg/src/gempyor/compartments.py
@@ -1,6 +1,4 @@
 """
-compartments.py
-
 Defines class, methods, and functions necessary to establising compartments in the model. 
 
 Classes:
@@ -27,7 +25,7 @@ from click import pass_context, Context
 
 from .utils import config, Timer, as_list
 from .shared_cli import config_files_argument, config_file_options, parse_config_files, cli
-from typing import Union
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -35,12 +33,6 @@ logger = logging.getLogger(__name__)
 class Compartments:
     """
     An object to handle compartment data for the model.
-
-    Arguments:
-        seir_config (optional): Config file for SEIR model construction information.
-        compartments_config (optional): Config file for compartment information.
-        compartments_file (optional): File to specify compartment information.
-        transitions_file (optional): File to specify transition information.
 
     Attributes:
         times_set: Counter to track succesful data intialization from config.
@@ -54,6 +46,15 @@ class Compartments:
         compartments_file=None,
         transitions_file=None,
     ):
+        """
+        Initializes a `Compartments` object.
+
+        Args:
+            seir_config: Config file for SEIR model construction information.
+            compartments_config: Config file for compartment information.
+            compartments_file: File to specify compartment information.
+            transitions_file: File to specify transition information.
+        """
         self.times_set = 0
 
         ## Something like this is needed for check script:
@@ -115,7 +116,7 @@ class Compartments:
 
         Args:
             seir_config: Configuraton information for model.
-            fake_config (optional):
+            fake_config:
                 Flag indicating whether or not transitions provied are placeholders.
                 Default value is False.
         Returns:
@@ -505,14 +506,14 @@ class Compartments:
 
     def get_comp_idx(self, comp_dict: dict, error_info: str = "no information") -> int:
         """
-        Return the index of a compartiment given a filter. The filter has to isolate a compartiment,
-        but it ignore columns that don't exist:
+        Return the index of a compartiment given a filter. The filter has to isolate a compartment,
+        but it ignores columns that don't exist:
 
         Args:
             comp_dict:
                 A dictionary where keys are compartment names and
                 values are values to filter by for each column.
-            error_info (optional):
+            error_info:
                 A message providing additional context about where the
                 the method was called from. Default value is "no information".
 
@@ -542,11 +543,11 @@ class Compartments:
         Constructs the transition matrix for the model.
 
         Returns:
-            tuple:
-                - a list of unique strings from `proportion_exponent` and `rate`
-                - array representing transitions and corresponding compartment indices.
-                - array representing proportion compartment indices
-                - array containing start and end indices for proportions
+            tuple[list[str], np.ndarray, np.ndarray, np.ndarray]:
+                - unique_strings: unique strings from `proportion_exponent` and `rate`
+                - transition_array: array representing transitions and corresponding compartment indices.
+                - proportion_array: array representing proportion compartment indices
+                - proportion_info: array containing start and end indices for proportions
 
         Raises:
             ValueError: If term is not found in list of valid compartments.
@@ -855,8 +856,7 @@ class Compartments:
 
     def get_compartments_explicitDF(self) -> pd.DataFrame:
         """
-        Returns a copy of the compartments information DataFrame.
-        All columns receive a 'mc_' prefix.
+        Returns a copy of the compartments information DataFrame; all columns receive a 'mc_' prefix.
 
         Returns:
             A copy of the compartments DataFrame.
@@ -920,7 +920,7 @@ class Compartments:
         src.render(output_file)
 
 
-def get_list_dimension(thing: any) -> int:
+def get_list_dimension(thing: Any) -> int:
     """
     Returns the dimension of a given object.
 
@@ -928,7 +928,7 @@ def get_list_dimension(thing: any) -> int:
         thing: Object whose dimension needs to be determined.
 
     Returns:
-        int: Length of the object if a list, otherwise 1.
+        Length of the object if a list, otherwise 1.
     """
     if type(thing) == list:
         return len(thing)
@@ -936,16 +936,16 @@ def get_list_dimension(thing: any) -> int:
 
 
 def list_access_element_safe(
-    thing: any, idx: int, dimension=None, encapsulate_as_list=False
-) -> Union[any, list]:
+    thing: Any, idx: int, dimension=None, encapsulate_as_list=False
+) -> Any | list[Any]:
     """
     Attempts to access an element from the given object `thing` at the specified index `idx`.
 
     Args:
         thing: Object to be accessed from.
         idx: Index of object you would like to access.
-        dimension (optional): Dimension or shape of the object.
-        encapsulate_as_list (optional): If `True`, the accessed element will be returned as a list.
+        dimension: Dimension or shape of the object.
+        encapsulate_as_list: If `True`, the accessed element will be returned as a list. Default is False.
 
     Raises:
         Exception: If `thing` is not iterable or `idx ` is out of range.
@@ -968,8 +968,8 @@ def list_access_element_safe(
 
 
 def list_access_element(
-    thing: any, idx: int, dimension=None, encapsulate_as_list=False
-) -> Union[any, list]:
+    thing: Any, idx: int, dimension=None, encapsulate_as_list=False
+) -> Any | list[Any]:
     """
     Access an element from a list or return the input itself if not a list.
     If input `thing` is a list, the function will return the element at the specified index (`idx`).
@@ -977,6 +977,10 @@ def list_access_element(
     `idx` value.
 
     Args:
+        thing: Object to be accessed from.
+        idx: Index of object you would like to access.
+        dimension: Dimension or shape of the object.
+        encapsulate_as_list: If `True`, the accessed element will be returned as a list. Default is False.
 
     Returns:
         Item at `idx` if `thing` is list, or
@@ -998,7 +1002,7 @@ def list_access_element(
         return rc
 
 
-def list_recursive_convert_to_string(thing: any) -> str:
+def list_recursive_convert_to_string(thing: Any) -> str:
     """
     Return given object as a str,
     or recursively convert elements of given list to strs.
@@ -1019,8 +1023,6 @@ def list_recursive_convert_to_string(thing: any) -> str:
 def compartments(ctx: Context):
     """
     Add commands for working with FlepiMoP compartments.
-    A container for subcommands `plot` and `export`.
-    Commands in this container will require context about the compartmental model.
     """
     pass
 

--- a/flepimop/gempyor_pkg/src/gempyor/compartments.py
+++ b/flepimop/gempyor_pkg/src/gempyor/compartments.py
@@ -14,18 +14,18 @@ Functions:
     export: Export compartment data to a CSV file. 
 """
 
+import logging
 from functools import reduce
+from typing import Any
 
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
-import logging
 from click import pass_context, Context
 
 from .utils import config, Timer, as_list
 from .shared_cli import config_files_argument, config_file_options, parse_config_files, cli
-from typing import Any
 
 logger = logging.getLogger(__name__)
 

--- a/flepimop/gempyor_pkg/src/gempyor/compartments.py
+++ b/flepimop/gempyor_pkg/src/gempyor/compartments.py
@@ -856,7 +856,9 @@ class Compartments:
 
     def get_compartments_explicitDF(self) -> pd.DataFrame:
         """
-        Returns a copy of the compartments information DataFrame; all columns receive a 'mc_' prefix.
+        Returns a copy of the compartments information DataFrame.
+
+        All columns receive a 'mc_' prefix.
 
         Returns:
             A copy of the compartments DataFrame.

--- a/flepimop/gempyor_pkg/src/gempyor/inference.py
+++ b/flepimop/gempyor_pkg/src/gempyor/inference.py
@@ -30,22 +30,23 @@ Functions:
         parameters based on this info. Returns the reduced parameters.
 """
 
-from concurrent.futures import ProcessPoolExecutor
-import copy
-import logging
-import multiprocessing as mp
 import os
+import logging
+import copy
+import multiprocessing as mp
+from concurrent.futures import ProcessPoolExecutor
 
-import numba as nb
 import numpy as np
 import pandas as pd
 import pyarrow.parquet as pq
 import xarray as xr
+import numba as nb
+
+from typing import Literal
 
 from . import seir, model_info
 from . import outcomes, file_paths
 from .utils import config, Timer, read_df, as_list
-from typing import Literal
 
 
 logging.basicConfig(level=os.environ.get("FLEPI_LOGLEVEL", "INFO").upper())

--- a/flepimop/gempyor_pkg/src/gempyor/inference.py
+++ b/flepimop/gempyor_pkg/src/gempyor/inference.py
@@ -342,10 +342,10 @@ class GempyorInference:
     """
     Encapsulates the process of simulation. Provides functionality for parameter
     inference, SEIR model execution, outcome computation, and inference optimization.
-    
+
     Attributes:
         seir_modifiers_scenario:
-        outcome_modifiers_scenario: 
+        outcome_modifiers_scenario:
         modinf: A `ModelInfo` object.
         already_built: Flag to determine if necessary objects have been built.
         autowrite_seir: Flag to automatically write SEIR data after simulation.
@@ -354,19 +354,20 @@ class GempyorInference:
         silent: Flag indicating whether to supress output messaging.
         save: Flag indicating whether simulation results should be saved.
     """
+
     def __init__(
         self,
         config_filepath,
-        run_id = "test_run_id",
+        run_id="test_run_id",
         prefix: str = None,
         first_sim_index: int = 1,
         stoch_traj_flag: bool = False,
-        rng_seed = None,
+        rng_seed=None,
         nslots: int = 1,
         inference_filename_prefix: str = "",  # usually for {global or chimeric}/{intermediate or final}
         inference_filepath_suffix: str = "",  # usually for the slot_id
-        out_run_id = None,  # if out_run_id is different from in_run_id, fill this
-        out_prefix = None,  # if out_prefix is different from in_prefix, fill this
+        out_run_id=None,  # if out_run_id is different from in_run_id, fill this
+        out_prefix=None,  # if out_prefix is different from in_prefix, fill this
         path_prefix: str = "",  # in case the data folder is on another directory
         autowrite_seir: bool = False,
     ):
@@ -378,8 +379,8 @@ class GempyorInference:
             config_filepath: Path to the config file.
 
         Optional Args:
-            run_id: ID of the run. 
-            prefix: Prefix for files. 
+            run_id: ID of the run.
+            prefix: Prefix for files.
             first_sim_index: Index of first simulation, default is 1.
             stoch_traj_flag: Whether to run the model stochastically, default is False.
             rng_seed: Number of slots for parallel computation.
@@ -624,7 +625,7 @@ class GempyorInference:
     ):
         """
         Method to oversee inference simulation.
-        You can optionally load previous simulation data as well. 
+        You can optionally load previous simulation data as well.
 
         Args:
             sim_id2write: ID of the simulation to be written.
@@ -831,11 +832,11 @@ class GempyorInference:
         Args:
             load_ID: Whether to load a previous simulation's data, default is False.
             sim_id2load: ID of simulation to be loaded, default is None.
-            bypass_DF: An alternative data frame to use during outcome modifier construction, default is None. 
-            bypass_FN: An alternative function to use during outcome modifier construction, default is None. 
+            bypass_DF: An alternative data frame to use during outcome modifier construction, default is None.
+            bypass_FN: An alternative function to use during outcome modifier construction, default is None.
 
         Returns:
-            npi_outcomes: An object that contains computed NPI outcome modifiers. 
+            npi_outcomes: An object that contains computed NPI outcome modifiers.
         """
         npi_outcomes = None
         if self.modinf.npi_config_outcomes:
@@ -851,16 +852,16 @@ class GempyorInference:
 
     def get_seir_npi(self, load_ID=False, sim_id2load=None, bypass_DF=None, bypass_FN=None):
         """
-        Builds the SEIR non-pharmaceutical interventions information. 
+        Builds the SEIR non-pharmaceutical interventions information.
 
         Args:
             load_ID: Whether to load a previous simulation's data, default is False.
             sim_id2load: ID of simulation to be loaded, default is None.
-            bypass_DF: An alternative data frame to use during outcome modifier construction, default is None. 
-            bypass_FN: An alternative function to use during outcome modifier construction, default is None. 
-        
+            bypass_DF: An alternative data frame to use during outcome modifier construction, default is None.
+            bypass_FN: An alternative function to use during outcome modifier construction, default is None.
+
         Returns:
-            npi_seir: An object that contains NPI parameters for the SEIR model. 
+            npi_seir: An object that contains NPI parameters for the SEIR model.
         """
         npi_seir = seir.build_npi_SEIR(
             modinf=self.modinf,
@@ -881,8 +882,8 @@ class GempyorInference:
         Args:
             load_ID: Whether to load a previous simulation's data, default is False.
             sim_id2load: ID of simulation to be loaded, default is None.
-            bypass_DF: An alternative data frame to use during outcome modifier construction, default is None. 
-            bypass_FN: An alternative function to use during outcome modifier construction, default is None. 
+            bypass_DF: An alternative data frame to use during outcome modifier construction, default is None.
+            bypass_FN: An alternative function to use during outcome modifier construction, default is None.
 
         Returns:
             p_draw: An array containing the drawn model parameters.
@@ -919,7 +920,7 @@ class GempyorInference:
             bypass_DF: An alternative data frame to use during outcome modifier construction, default is None.
             bypass_FN: An alternative function to use during outcome modifier construction, default is None.
 
-        Returns: 
+        Returns:
             A pd.DatyaFrame containing the SEIR model parameters.
         """
         p_draw = self.get_seir_parameters(
@@ -940,18 +941,18 @@ class GempyorInference:
         bypass_FN=None,
     ):
         """
-        Retreives and reduces SEIR model parameters and returns them as a pd.DataFrame. 
+        Retreives and reduces SEIR model parameters and returns them as a pd.DataFrame.
 
         Args:
             npi_seir: A dictionary of NPI parameters.
-            p_draw: An array containing drawn model parameters, default is None. 
+            p_draw: An array containing drawn model parameters, default is None.
             load_ID: Whether to load a previous simulation's data, default is False.
             sim_id2load: ID of simulation to be loaded, default is None.
             bypass_DF: An alternative data frame to use during outcome modifier construction, default is None.
             bypass_FN: An alternative function to use during outcome modifier construction, default is None.
-        
+
         Returns:
-            A pd.DataFrame containing reduced SEIR model parameters. 
+            A pd.DataFrame containing reduced SEIR model parameters.
         """
         if p_draw is None:
             p_draw = self.get_seir_parameters(

--- a/flepimop/gempyor_pkg/src/gempyor/inference.py
+++ b/flepimop/gempyor_pkg/src/gempyor/inference.py
@@ -8,6 +8,29 @@
 # This populate the namespace with four functions, with return value 0 if the
 # function terminated successfully
 
+"""
+inference.py
+
+Class:
+    GempyorInference: 
+        Encapsulates the process of simulation. Provides functionality for parameter
+        inference, SEIR model execution, outcome computation, and inference optimization.
+
+Functions:
+    simulation_atomic: 
+        Runs a SEIR simulation (generates and reduces parameters, executes SEIR
+        processes, computes outcomes, handles NPIs and seeding data).
+    get_static_arguments: Get the static arguments for the log likelihood function.
+    autodetect_senarios: Auto-detect the scenarios provided in config.
+    paramred_parallel: 
+        Initializes a `GempyorInference` object with a configuration file, 
+        reads specified NPI file, and computes reduced SEIR model specifications
+        based on this info. Returns the reduced parameters.
+    paramred_parallel_config: 
+        Initializes a `GempyorInference` object with a configuration file,
+        retreives SEIR model specifications and NPIs, and computes reduced
+        parameters based on this info. Returns the reduced parameters.
+"""
 
 from concurrent.futures import ProcessPoolExecutor
 import copy
@@ -316,22 +339,58 @@ def autodetect_scenarios(config):
 
 
 class GempyorInference:
+    """
+    Encapsulates the process of simulation. Provides functionality for parameter
+    inference, SEIR model execution, outcome computation, and inference optimization.
+    
+    Attributes:
+        seir_modifiers_scenario:
+        outcome_modifiers_scenario: 
+        modinf: A `ModelInfo` object.
+        already_built: Flag to determine if necessary objects have been built.
+        autowrite_seir: Flag to automatically write SEIR data after simulation.
+        static_sim_arguments: Dictionary containing static simulation arguments.
+        do_inference: Flag to determine if model should be run with inference.
+        silent: Flag indicating whether to supress output messaging.
+        save: Flag indicating whether simulation results should be saved.
+    """
     def __init__(
         self,
         config_filepath,
-        run_id="test_run_id",
-        prefix=None,
-        first_sim_index=1,
-        stoch_traj_flag=False,
-        rng_seed=None,
-        nslots=1,
-        inference_filename_prefix="",  # usually for {global or chimeric}/{intermediate or final}
-        inference_filepath_suffix="",  # usually for the slot_id
-        out_run_id=None,  # if out_run_id is different from in_run_id, fill this
-        out_prefix=None,  # if out_prefix is different from in_prefix, fill this
-        path_prefix="",  # in case the data folder is on another directory
-        autowrite_seir=False,
+        run_id = "test_run_id",
+        prefix: str = None,
+        first_sim_index: int = 1,
+        stoch_traj_flag: bool = False,
+        rng_seed = None,
+        nslots: int = 1,
+        inference_filename_prefix: str = "",  # usually for {global or chimeric}/{intermediate or final}
+        inference_filepath_suffix: str = "",  # usually for the slot_id
+        out_run_id = None,  # if out_run_id is different from in_run_id, fill this
+        out_prefix = None,  # if out_prefix is different from in_prefix, fill this
+        path_prefix: str = "",  # in case the data folder is on another directory
+        autowrite_seir: bool = False,
     ):
+        """
+        Initializes the `GempyorInference` object by loading config, setting
+        up the model, and configuring inference parameters.
+
+        Non-optinal Arg:
+            config_filepath: Path to the config file.
+
+        Optional Args:
+            run_id: ID of the run. 
+            prefix: Prefix for files. 
+            first_sim_index: Index of first simulation, default is 1.
+            stoch_traj_flag: Whether to run the model stochastically, default is False.
+            rng_seed: Number of slots for parallel computation.
+            nslots: Number of slots, default is 1.
+            inference_filename_prefix: Prefix for inference-related file paths.
+            inference_filepath_suffix: Suffix for inference-related file paths.
+            out_run_id: ID for run output.
+            out_prefix: Prefix for file paths to output.
+            path_prefix: Prefix for paths to files (in case data folder is in another directory)
+            autowrite_seir: Flag to automatically write SEIR data after simulation, defaul is False.
+        """
         # Config prep
         config.clear()
         config.read(user=False)
@@ -563,6 +622,21 @@ class GempyorInference:
         sim_id2load: int = None,
         parallel=False,
     ):
+        """
+        Method to oversee inference simulation.
+        You can optionally load previous simulation data as well. 
+
+        Args:
+            sim_id2write: ID of the simulation to be written.
+            load_ID: Wether to load a previous simulation's data, default is False.
+            sim_id2load: ID of simulation to be loaded, default is None.
+            parallel: Whether to run simulation in parallel chains, default is False.
+
+        Returns: 0
+
+        Raises:
+            ValueError: If `load_ID` is True and `sim_id2load` is not provided.
+        """
         sim_id2write = int(sim_id2write)
         self.lastsim_sim_id2write = sim_id2write
         self.lastsim_loadID = load_ID
@@ -751,6 +825,18 @@ class GempyorInference:
     def get_outcome_npi(
         self, load_ID=False, sim_id2load=None, bypass_DF=None, bypass_FN=None
     ):
+        """
+        Builds the non-pharmaceutical intervention outcome modifiers.
+
+        Args:
+            load_ID: Whether to load a previous simulation's data, default is False.
+            sim_id2load: ID of simulation to be loaded, default is None.
+            bypass_DF: An alternative data frame to use during outcome modifier construction, default is None. 
+            bypass_FN: An alternative function to use during outcome modifier construction, default is None. 
+
+        Returns:
+            npi_outcomes: An object that contains computed NPI outcome modifiers. 
+        """
         npi_outcomes = None
         if self.modinf.npi_config_outcomes:
             npi_outcomes = outcomes.build_outcome_modifiers(
@@ -764,6 +850,18 @@ class GempyorInference:
         return npi_outcomes
 
     def get_seir_npi(self, load_ID=False, sim_id2load=None, bypass_DF=None, bypass_FN=None):
+        """
+        Builds the SEIR non-pharmaceutical interventions information. 
+
+        Args:
+            load_ID: Whether to load a previous simulation's data, default is False.
+            sim_id2load: ID of simulation to be loaded, default is None.
+            bypass_DF: An alternative data frame to use during outcome modifier construction, default is None. 
+            bypass_FN: An alternative function to use during outcome modifier construction, default is None. 
+        
+        Returns:
+            npi_seir: An object that contains NPI parameters for the SEIR model. 
+        """
         npi_seir = seir.build_npi_SEIR(
             modinf=self.modinf,
             load_ID=load_ID,
@@ -777,6 +875,18 @@ class GempyorInference:
     def get_seir_parameters(
         self, load_ID=False, sim_id2load=None, bypass_DF=None, bypass_FN=None
     ):
+        """
+        Generates SEIR model parameters.
+
+        Args:
+            load_ID: Whether to load a previous simulation's data, default is False.
+            sim_id2load: ID of simulation to be loaded, default is None.
+            bypass_DF: An alternative data frame to use during outcome modifier construction, default is None. 
+            bypass_FN: An alternative function to use during outcome modifier construction, default is None. 
+
+        Returns:
+            p_draw: An array containing the drawn model parameters.
+        """
         param_df = None
         if bypass_DF is not None:
             param_df = bypass_DF
@@ -800,6 +910,18 @@ class GempyorInference:
     def get_seir_parametersDF(
         self, load_ID=False, sim_id2load=None, bypass_DF=None, bypass_FN=None
     ):
+        """
+        Retreive SEIR parameters and return them as a pd.DataFrame.
+
+        Args:
+            load_ID: Whether to load a previous simulation's data, default is False.
+            sim_id2load: ID of simulation to be loaded, default is None.
+            bypass_DF: An alternative data frame to use during outcome modifier construction, default is None.
+            bypass_FN: An alternative function to use during outcome modifier construction, default is None.
+
+        Returns: 
+            A pd.DatyaFrame containing the SEIR model parameters.
+        """
         p_draw = self.get_seir_parameters(
             load_ID=load_ID,
             sim_id2load=sim_id2load,
@@ -817,6 +939,20 @@ class GempyorInference:
         bypass_DF=None,
         bypass_FN=None,
     ):
+        """
+        Retreives and reduces SEIR model parameters and returns them as a pd.DataFrame. 
+
+        Args:
+            npi_seir: A dictionary of NPI parameters.
+            p_draw: An array containing drawn model parameters, default is None. 
+            load_ID: Whether to load a previous simulation's data, default is False.
+            sim_id2load: ID of simulation to be loaded, default is None.
+            bypass_DF: An alternative data frame to use during outcome modifier construction, default is None.
+            bypass_FN: An alternative function to use during outcome modifier construction, default is None.
+        
+        Returns:
+            A pd.DataFrame containing reduced SEIR model parameters. 
+        """
         if p_draw is None:
             p_draw = self.get_seir_parameters(
                 load_ID=load_ID,

--- a/flepimop/gempyor_pkg/src/gempyor/inference.py
+++ b/flepimop/gempyor_pkg/src/gempyor/inference.py
@@ -9,9 +9,7 @@
 # function terminated successfully
 
 """
-inference.py
-
-Class:
+Classes:
     GempyorInference: 
         Encapsulates the process of simulation. Provides functionality for parameter
         inference, SEIR model execution, outcome computation, and inference optimization.
@@ -47,6 +45,7 @@ import xarray as xr
 from . import seir, model_info
 from . import outcomes, file_paths
 from .utils import config, Timer, read_df, as_list
+from typing import Literal
 
 
 logging.basicConfig(level=os.environ.get("FLEPI_LOGLEVEL", "INFO").upper())
@@ -340,8 +339,10 @@ def autodetect_scenarios(config):
 
 class GempyorInference:
     """
-    Encapsulates the process of simulation. Provides functionality for parameter
-    inference, SEIR model execution, outcome computation, and inference optimization.
+    Class to encapsulate the process of inference simulation.
+
+    Provides functionality for parameter inference, SEIR model execution,
+    outcome computation, and inference optimization.
 
     Attributes:
         seir_modifiers_scenario:
@@ -359,7 +360,7 @@ class GempyorInference:
         self,
         config_filepath,
         run_id="test_run_id",
-        prefix: str = None,
+        prefix: str | None = None,
         first_sim_index: int = 1,
         stoch_traj_flag: bool = False,
         rng_seed=None,
@@ -372,13 +373,10 @@ class GempyorInference:
         autowrite_seir: bool = False,
     ):
         """
-        Initializes the `GempyorInference` object by loading config, setting
-        up the model, and configuring inference parameters.
+        Initializes the `GempyorInference` object by loading config, setting up the model, and configuring inference parameters.
 
-        Non-optinal Arg:
+        Args:
             config_filepath: Path to the config file.
-
-        Optional Args:
             run_id: ID of the run.
             prefix: Prefix for files.
             first_sim_index: Index of first simulation, default is 1.
@@ -390,7 +388,7 @@ class GempyorInference:
             out_run_id: ID for run output.
             out_prefix: Prefix for file paths to output.
             path_prefix: Prefix for paths to files (in case data folder is in another directory)
-            autowrite_seir: Flag to automatically write SEIR data after simulation, defaul is False.
+            autowrite_seir: Flag to automatically write SEIR data after simulation, default is False.
         """
         # Config prep
         config.clear()
@@ -622,7 +620,7 @@ class GempyorInference:
         load_ID: bool = False,
         sim_id2load: int = None,
         parallel=False,
-    ):
+    ) -> Literal[0]:
         """
         Method to oversee inference simulation.
         You can optionally load previous simulation data as well.
@@ -630,7 +628,7 @@ class GempyorInference:
         Args:
             sim_id2write: ID of the simulation to be written.
             load_ID: Wether to load a previous simulation's data, default is False.
-            sim_id2load: ID of simulation to be loaded, default is None.
+            sim_id2load: ID of simulation to be loaded.
             parallel: Whether to run simulation in parallel chains, default is False.
 
         Returns: 0
@@ -827,13 +825,13 @@ class GempyorInference:
         Builds the non-pharmaceutical intervention outcome modifiers.
 
         Args:
-            load_ID: Whether to load a previous simulation's data, default is False.
-            sim_id2load: ID of simulation to be loaded, default is None.
-            bypass_DF: An alternative data frame to use during outcome modifier construction, default is None.
-            bypass_FN: An alternative function to use during outcome modifier construction, default is None.
+            load_ID: Whether to load a previous simulation's data.
+            sim_id2load: ID of simulation to be loaded.
+            bypass_DF: An alternative data frame to use during outcome modifier construction.
+            bypass_FN: An alternative function to use during outcome modifier construction.
 
         Returns:
-            npi_outcomes: An object that contains computed NPI outcome modifiers.
+            An object that contains computed NPI outcome modifiers.
         """
         npi_outcomes = None
         if self.modinf.npi_config_outcomes:
@@ -853,9 +851,9 @@ class GempyorInference:
 
         Args:
             load_ID: Whether to load a previous simulation's data, default is False.
-            sim_id2load: ID of simulation to be loaded, default is None.
-            bypass_DF: An alternative data frame to use during outcome modifier construction, default is None.
-            bypass_FN: An alternative function to use during outcome modifier construction, default is None.
+            sim_id2load: ID of simulation to be loaded.
+            bypass_DF: An alternative data frame to use during outcome modifier construction.
+            bypass_FN: An alternative function to use during outcome modifier construction.
 
         Returns:
             npi_seir: An object that contains NPI parameters for the SEIR model.
@@ -878,9 +876,9 @@ class GempyorInference:
 
         Args:
             load_ID: Whether to load a previous simulation's data, default is False.
-            sim_id2load: ID of simulation to be loaded, default is None.
-            bypass_DF: An alternative data frame to use during outcome modifier construction, default is None.
-            bypass_FN: An alternative function to use during outcome modifier construction, default is None.
+            sim_id2load: ID of simulation to be loaded.
+            bypass_DF: An alternative data frame to use during outcome modifier construction.
+            bypass_FN: An alternative function to use during outcome modifier construction.
 
         Returns:
             p_draw: An array containing the drawn model parameters.
@@ -913,9 +911,9 @@ class GempyorInference:
 
         Args:
             load_ID: Whether to load a previous simulation's data, default is False.
-            sim_id2load: ID of simulation to be loaded, default is None.
-            bypass_DF: An alternative data frame to use during outcome modifier construction, default is None.
-            bypass_FN: An alternative function to use during outcome modifier construction, default is None.
+            sim_id2load: ID of simulation to be loaded.
+            bypass_DF: An alternative data frame to use during outcome modifier construction.
+            bypass_FN: An alternative function to use during outcome modifier construction.
 
         Returns:
             A pd.DatyaFrame containing the SEIR model parameters.
@@ -942,11 +940,11 @@ class GempyorInference:
 
         Args:
             npi_seir: A dictionary of NPI parameters.
-            p_draw: An array containing drawn model parameters, default is None.
+            p_draw: An array containing drawn model parameters.
             load_ID: Whether to load a previous simulation's data, default is False.
-            sim_id2load: ID of simulation to be loaded, default is None.
-            bypass_DF: An alternative data frame to use during outcome modifier construction, default is None.
-            bypass_FN: An alternative function to use during outcome modifier construction, default is None.
+            sim_id2load: ID of simulation to be loaded.
+            bypass_DF: An alternative data frame to use during outcome modifier construction.
+            bypass_FN: An alternative function to use during outcome modifier construction.
 
         Returns:
             A pd.DataFrame containing reduced SEIR model parameters.

--- a/flepimop/gempyor_pkg/src/gempyor/model_info.py
+++ b/flepimop/gempyor_pkg/src/gempyor/model_info.py
@@ -33,8 +33,8 @@ class TimeSetup:
     """
     Handles the simulation time frame based on config info.
 
-    `TimeSetup` reads the start and end dates from the config, validates the time frame, 
-    and calculates the number of days in the simulation. It also establishes a 
+    `TimeSetup` reads the start and end dates from the config, validates the time frame,
+    and calculates the number of days in the simulation. It also establishes a
     pd.DatetimeIndex for the entire simulation period.
 
     Args:
@@ -47,6 +47,7 @@ class TimeSetup:
         n_days (int): Total number of days in the simulation time frame.
         dates (pd.DatetimeIndex): A sequence of dates spanning the simulation time frame (inclusive of the start and end dates).
     """
+
     def __init__(self, config: confuse.ConfigView):
         self.ti = config["start_date"].as_date()
         self.tf = config["end_date"].as_date()
@@ -60,27 +61,27 @@ class TimeSetup:
 
 class ModelInfo:
     """
-    Parse config file and manage file input/output. 
+    Parse config file and manage file input/output.
 
     Non-optional Arg:
         config: Config object.
     Optional Args:
-        nslots: Number of slots for MCMC (default is 1). 
-        write_csv: Whether to write results to CSV files (default is False). 
+        nslots: Number of slots for MCMC (default is 1).
+        write_csv: Whether to write results to CSV files (default is False).
         write_parquet: Whether to write results to parquet files (default is False). **
-        first_sim_index : Index of first simulation (default is 1). 
+        first_sim_index : Index of first simulation (default is 1).
         stoch_traj_flag: Whether to run the model stochastically (default is False). **
-        seir_modifiers_scenario: SEIR modifier. 
-        outcome_modifiers_scenario: Outcomes modifier. 
-        setup_name: Name of setup (to override config, if applicable). 
-        path_prefix: Prefix to paths where simulation data files are stored. 
+        seir_modifiers_scenario: SEIR modifier.
+        outcome_modifiers_scenario: Outcomes modifier.
+        setup_name: Name of setup (to override config, if applicable).
+        path_prefix: Prefix to paths where simulation data files are stored.
         in_run_id: ID for input run (generated if not specified).
         out_run_id: ID for outputr run (generated if not specified).
-        in_prefix: Path prefix for input directory. 
-        out_prefix: Path prefix for output directory. 
-        inference_filename_prefix: Path prefix for inference files directory. 
-        inference_filepath_suffix: Path suffix for inference files directory. 
-        config_filepath: Path to configuration file. 
+        in_prefix: Path prefix for input directory.
+        out_prefix: Path prefix for output directory.
+        inference_filename_prefix: Path prefix for inference files directory.
+        inference_filepath_suffix: Path suffix for inference files directory.
+        config_filepath: Path to configuration file.
     All optional args are inherited as attributes.
 
     Additional Attributes:
@@ -88,7 +89,7 @@ class ModelInfo:
         ti: Initial time (time start).
         tf: Final time (fime finish).
         n_days: Number of days in simulation.
-        dates: pd.DatetimeIndex sequence of dates that span simulation. 
+        dates: pd.DatetimeIndex sequence of dates that span simulation.
         subpop_struct: `SubpopulationStructure` object (info about subpops).
         nsubpops: Number of subpopulations in simulation.
         subpop_pop: NumPy array containing population of each subpop.
@@ -108,7 +109,7 @@ class ModelInfo:
         ValueError:
             If provided configuration information is incompatible with expectations.
         ValueError:
-            If non-existent sections are referenced. 
+            If non-existent sections are referenced.
         NotImplementedError:
             If an unimplemented feature is referenced.
 

--- a/flepimop/gempyor_pkg/src/gempyor/model_info.py
+++ b/flepimop/gempyor_pkg/src/gempyor/model_info.py
@@ -9,8 +9,8 @@ This submodule is intended to serve as a foundational part of flepiMoP's
 infrastructure for conducting simulations and storing results.
 
 Classes:
-    TimeSetup:
-    ModelInfo:
+    TimeSetup: Handles simulation time frame.
+    ModelInfo: Parses config file, holds model information, and manages file input/output.
 """
 
 import pandas as pd
@@ -61,7 +61,7 @@ class TimeSetup:
 
 class ModelInfo:
     """
-    Parse config file and manage file input/output.
+    Parses config file, holds model information, and manages file input/output.
 
     Non-optional Arg:
         config: Config object.

--- a/flepimop/gempyor_pkg/src/gempyor/model_info.py
+++ b/flepimop/gempyor_pkg/src/gempyor/model_info.py
@@ -1,6 +1,4 @@
 """
-model_info.py
-
 Defines the `ModelInfo` class (and associated methods), used for setting up and 
 managing the configuration of a simulation. The primary focuses of a `ModelInfo` object
 are parsing and validating config details (including time frames, subpop info, 
@@ -46,10 +44,6 @@ class TimeSetup:
     and calculates the number of days in the simulation. It also establishes a
     pd.DatetimeIndex for the entire simulation period.
 
-    Args:
-        config: A config object.
-
-
     Attributes:
         ti (datetime.date): Start date of simulation.
         tf (datetime.date): End date of simulation.
@@ -58,6 +52,12 @@ class TimeSetup:
     """
 
     def __init__(self, config: confuse.ConfigView):
+        """
+        Initializes a `TimeSetup` object.
+
+        Args:
+            config: A configuration confuse.ConfigView object.
+        """
         self.ti = config["start_date"].as_date()
         self.tf = config["end_date"].as_date()
         if self.tf <= self.ti:
@@ -72,28 +72,15 @@ class ModelInfo:
     """
     Parses config file, holds model information, and manages file input/output.
 
-    Non-optional Arg:
-        config: Config object.
-    Optional Args:
-        nslots: Number of slots for MCMC (default is 1).
+    Attributes:
+        nslots: Number of slots for MCMC.
         write_csv: Whether to write results to CSV files (default is False).
-        write_parquet: Whether to write results to parquet files (default is False). **
-        first_sim_index : Index of first simulation (default is 1).
-        stoch_traj_flag: Whether to run the model stochastically (default is False). **
-        seir_modifiers_scenario: SEIR modifier.
+        write_parquet: Whether to write results to parquet files (default is False)
+        first_sim_index: Index of first simulation (default is 1).
+        stoch_traj_flag: Whether to run the model stochastically (default is False).
+        seir_modifiers_scenario: seir_modifiers_scenario: SEIR modifier.
         outcome_modifiers_scenario: Outcomes modifier.
         setup_name: Name of setup (to override config, if applicable).
-        path_prefix: Prefix to paths where simulation data files are stored.
-        in_run_id: ID for input run (generated if not specified).
-        out_run_id: ID for outputr run (generated if not specified).
-        in_prefix: Path prefix for input directory.
-        out_prefix: Path prefix for output directory.
-        inference_filename_prefix: Path prefix for inference files directory.
-        inference_filepath_suffix: Path suffix for inference files directory.
-        config_filepath: Path to configuration file.
-    All optional args are inherited as attributes.
-
-    Additional Attributes:
         time_setup: `TimeSetup` object (start/end dates of simulation, as pd.DatetimeIndex).
         ti: Initial time (time start).
         tf: Final time (fime finish).
@@ -103,8 +90,11 @@ class ModelInfo:
         nsubpops: Number of subpopulations in simulation.
         subpop_pop: NumPy array containing population of each subpop.
         mobility: Matrix with values representing movement of people between subpops.
+        path_prefix: Prefix to paths where simulation data files are stored.
         seir_config: SEIR configuration info, if relevant for simulation.
         seir_modifiers_library: Modifiers for SEIR model, if relevant for simulation.
+        parameters_config: Parameter information from config.
+        initial_conditions_config: Initial conditions information from config.
         seeding_config: Seeding config, if relevant.
         parameters: `Parameter` object containing information about parameters.
         seeding: Seeding configuration information, if relevant.
@@ -113,6 +103,16 @@ class ModelInfo:
         compartments: `Compartments` object contianing information about compartments.
         outcomes_config: Outcomes configurations, if relevant.
         npi_config_outcomes: Non-pharmaceutical intervention outcome configurations, if relevant.
+        outcome_modifiers_library: Outcome modifiers, pulled from config.
+        in_run_id: ID for input run (generated if not specified).
+        out_run_id: ID for outputr run (generated if not specified).
+        in_prefix: Path prefix for input directory.
+        out_prefix: Path prefix for output directory.
+        inference_filename_prefix: Path prefix for inference files directory.
+        inference_filepath_suffix: Path suffix for inference files directory.
+        timestamp: Current datetime.
+        extension: File extensions.
+        config_filepath: Path to configuration file.
 
     Raises:
         ValueError:
@@ -158,6 +158,28 @@ class ModelInfo:
         setup_name=None,  # override config setup_name
         config_filepath="",
     ):
+        """
+        Initializes a `ModelInfo` object.
+
+        Args:
+            config: Config object.
+            nslots: Number of slots for MCMC (default is 1).
+            write_csv: Whether to write results to CSV files (default is False).
+            write_parquet: Whether to write results to parquet files (default is False).
+            first_sim_index : Index of first simulation (default is 1).
+            stoch_traj_flag: Whether to run the model stochastically (default is False).
+            seir_modifiers_scenario: SEIR modifier.
+            outcome_modifiers_scenario: Outcomes modifier.
+            setup_name: Name of setup (to override config, if applicable).
+            path_prefix: Prefix to paths where simulation data files are stored.
+            in_run_id: ID for input run (generated if not specified).
+            out_run_id: ID for outputr run (generated if not specified).
+            in_prefix: Path prefix for input directory.
+            out_prefix: Path prefix for output directory.
+            inference_filename_prefix: Path prefix for inference files directory.
+            inference_filepath_suffix: Path suffix for inference files directory.
+            config_filepath: Path to configuration file.
+        """
         self.nslots = nslots
         self.write_csv = write_csv
         self.write_parquet = write_parquet

--- a/flepimop/gempyor_pkg/src/gempyor/model_info.py
+++ b/flepimop/gempyor_pkg/src/gempyor/model_info.py
@@ -1,4 +1,6 @@
 """
+Abstractions for interacting with models as a monolithic object.
+
 Defines the `ModelInfo` class (and associated methods), used for setting up and 
 managing the configuration of a simulation. The primary focuses of a `ModelInfo` object
 are parsing and validating config details (including time frames, subpop info, 

--- a/flepimop/gempyor_pkg/src/gempyor/parameters.py
+++ b/flepimop/gempyor_pkg/src/gempyor/parameters.py
@@ -58,7 +58,7 @@ class Parameters:
         Parameters can be defined or drawn from distributions.
 
         Args:
-            parameter_config: A confuse.ConfigView subsetting the parameters section of a given
+            parameter_config: A view of the overall configuration object focused on the parameters section of a given
                 config file.
             ti: An initial date for simulation.
             tf: A final date for simulation.

--- a/flepimop/gempyor_pkg/src/gempyor/parameters.py
+++ b/flepimop/gempyor_pkg/src/gempyor/parameters.py
@@ -1,8 +1,12 @@
 """
-Abstractions for interacting with the parameters configurations.
+parameters.py
 
-This module contains abstractions for interacting with the parameters section of given
-config files. Namely it contains the `Parameters` class.
+Provides abstractions for interacting with the parameters configurations.
+
+Classes:
+    Parameters: 
+        Encapsulates logic for loading, parsing, and 
+        summarizing parameter configurations.
 """
 
 __all__ = ["Parameters"]
@@ -28,7 +32,15 @@ logger = logging.getLogger(__name__)
 class Parameters:
     """
     Encapsulates logic for loading, parsing, and summarizing parameter configurations.
+    Parameters can be defined or drawn from distributions.
 
+    Args:
+        parameter_config: Configuration information (in a confuse.ConfigView) for parameters.
+        ti: Initial time of simulation (time start).
+        tf: Final time of simulation (time finish). 
+        subpop_names: Names of all subpopulations.
+        path_prefix: Pathway prefix to directory with 
+    
     Attributes:
         npar: The number of parameters contained within the given configuration.
         pconfig: A view subsetting to the parameters section of a given config file.
@@ -39,6 +51,8 @@ class Parameters:
             attribute.
         stacked_modifier_method: A mapping of modifier method to the parameters to which
             that modifier method is relevant for.
+
+    Raises:
     """
 
     def __init__(
@@ -52,16 +66,28 @@ class Parameters:
     ):
         """
         Initialize a `Parameters` instance from a parameter config view.
+        Encapsulates logic for loading, parsing, and summarizing parameter configurations.
+        Parameters can be defined or drawn from distributions.
 
         Args:
-            parameter_config: A view subsetting to the parameters section of a given
+            parameter_config: A confuse.ConfigView subsetting the parameters section of a given
                 config file.
-            ti: An initial date.
-            tf: A final date.
+            ti: An initial date for simulation. 
+            tf: A final date for simulation.
             subpop_names: A list of subpopulation names.
-            path_prefix: A file path prefix to use when reading in parameter values from
-                a dataframe like file.
+            path_prefix: A file path prefix to directory containing parameter values.
 
+        Attributes:
+            pconfig: confuse.ConfigView of parameter configuration information.
+            pnames: A list of parameter names.
+            npar: Number of parameters.
+            pdata: A dictionary containing a processed and reformatted view of the `pconfig`
+                attribute.
+            pnames2pindex: A map of parameter names to their location in the `pnames`
+                attribute.
+            stacked_modifier_method: A map of modifier methods to the parameters which
+                that modifier method is relevant for.
+                
         Raises:
             ValueError: The parameter names for the SEIR model are not unique.
             ValueError: The dataframe file found for a given parameter contains an

--- a/flepimop/gempyor_pkg/src/gempyor/parameters.py
+++ b/flepimop/gempyor_pkg/src/gempyor/parameters.py
@@ -58,8 +58,8 @@ class Parameters:
         Parameters can be defined or drawn from distributions.
 
         Args:
-            parameter_config: A view of the overall configuration object focused on the parameters section of a given
-                config file.
+            parameter_config: A view of the overall configuration object focused on the parameters 
+                section of a given config file.
             ti: An initial date for simulation.
             tf: A final date for simulation.
             subpop_names: A list of subpopulation names.

--- a/flepimop/gempyor_pkg/src/gempyor/parameters.py
+++ b/flepimop/gempyor_pkg/src/gempyor/parameters.py
@@ -1,12 +1,9 @@
 """
-parameters.py
-
 Provides abstractions for interacting with the parameters configurations.
 
 Classes:
     Parameters: 
-        Encapsulates logic for loading, parsing, and 
-        summarizing parameter configurations.
+        Encapsulates logic for loading, parsing, and summarizing parameter configurations.
 """
 
 __all__ = ["Parameters"]
@@ -32,14 +29,6 @@ logger = logging.getLogger(__name__)
 class Parameters:
     """
     Encapsulates logic for loading, parsing, and summarizing parameter configurations.
-    Parameters can be defined or drawn from distributions.
-
-    Args:
-        parameter_config: Configuration information (in a confuse.ConfigView) for parameters.
-        ti: Initial time of simulation (time start).
-        tf: Final time of simulation (time finish).
-        subpop_names: Names of all subpopulations.
-        path_prefix: Pathway prefix to directory with
 
     Attributes:
         npar: The number of parameters contained within the given configuration.
@@ -51,8 +40,6 @@ class Parameters:
             attribute.
         stacked_modifier_method: A mapping of modifier method to the parameters to which
             that modifier method is relevant for.
-
-    Raises:
     """
 
     def __init__(
@@ -66,6 +53,7 @@ class Parameters:
     ):
         """
         Initialize a `Parameters` instance from a parameter config view.
+
         Encapsulates logic for loading, parsing, and summarizing parameter configurations.
         Parameters can be defined or drawn from distributions.
 
@@ -76,17 +64,6 @@ class Parameters:
             tf: A final date for simulation.
             subpop_names: A list of subpopulation names.
             path_prefix: A file path prefix to directory containing parameter values.
-
-        Attributes:
-            pconfig: confuse.ConfigView of parameter configuration information.
-            pnames: A list of parameter names.
-            npar: Number of parameters.
-            pdata: A dictionary containing a processed and reformatted view of the `pconfig`
-                attribute.
-            pnames2pindex: A map of parameter names to their location in the `pnames`
-                attribute.
-            stacked_modifier_method: A map of modifier methods to the parameters which
-                that modifier method is relevant for.
 
         Raises:
             ValueError: The parameter names for the SEIR model are not unique.

--- a/flepimop/gempyor_pkg/src/gempyor/parameters.py
+++ b/flepimop/gempyor_pkg/src/gempyor/parameters.py
@@ -37,10 +37,10 @@ class Parameters:
     Args:
         parameter_config: Configuration information (in a confuse.ConfigView) for parameters.
         ti: Initial time of simulation (time start).
-        tf: Final time of simulation (time finish). 
+        tf: Final time of simulation (time finish).
         subpop_names: Names of all subpopulations.
-        path_prefix: Pathway prefix to directory with 
-    
+        path_prefix: Pathway prefix to directory with
+
     Attributes:
         npar: The number of parameters contained within the given configuration.
         pconfig: A view subsetting to the parameters section of a given config file.
@@ -72,7 +72,7 @@ class Parameters:
         Args:
             parameter_config: A confuse.ConfigView subsetting the parameters section of a given
                 config file.
-            ti: An initial date for simulation. 
+            ti: An initial date for simulation.
             tf: A final date for simulation.
             subpop_names: A list of subpopulation names.
             path_prefix: A file path prefix to directory containing parameter values.
@@ -87,7 +87,7 @@ class Parameters:
                 attribute.
             stacked_modifier_method: A map of modifier methods to the parameters which
                 that modifier method is relevant for.
-                
+
         Raises:
             ValueError: The parameter names for the SEIR model are not unique.
             ValueError: The dataframe file found for a given parameter contains an

--- a/flepimop/gempyor_pkg/src/gempyor/parameters.py
+++ b/flepimop/gempyor_pkg/src/gempyor/parameters.py
@@ -58,7 +58,7 @@ class Parameters:
         Parameters can be defined or drawn from distributions.
 
         Args:
-            parameter_config: A view of the overall configuration object focused on the parameters 
+            parameter_config: A view of the overall configuration object focused on the parameters
                 section of a given config file.
             ti: An initial date for simulation.
             tf: A final date for simulation.


### PR DESCRIPTION
### Describe your changes.

This pull request:
- Adds inline docstring documentation to important (as identified by flepiMoP users) submodules, classes, methods, etc. within `gempyor`
- Improves existing docstring documentation, when reasonable to do so
- Removes some poor documentation, so that when we [use Sphinx in the future](https://github.com/HopkinsIDD/flepiMoP/issues/458) as a tool for documenting `gempyor`, it does not propagate poor documentation

As I see it, the `gempyor` API mainly consists of:
- `ModelInfo` class from `model_info.py`
- `Parameters` class from `parameters.py`, and some associated methods
- `GempyorInference` class from `inference.py`, and some associated methods
- `Compartments` class from `compartments.py`, and some associated methods
- and two functions from `utils.py` (`read_df` and `write_df`)

Note, before narrowing my focus on guidance from Carl, I also wrote some docstring in two files (`calibrate.py` and `cli.py`). I do not think of these as being integral parts of the `gempyor` API, but because I worked on them in in the same sweep of work that I worked on the others, they are also included in this PR with some docstring improvements. 

### What does your pull request address? Tag relevant issues.

This pull request addresses GH #462. 

