### PR TITLE
Fix R CI Actions With Ubuntu 22 To 24 Update

### DIFF
--- a/.github/workflows/flepicommon-ci.yml
+++ b/.github/workflows/flepicommon-ci.yml
@@ -42,7 +42,7 @@ jobs:
           r-version: ${{ matrix.R-version }}
           update-rtools: true
       - name: Install System Dependencies
-        run: sudo apt install libcurl4-openssl-dev libharfbuzz-dev libfribidi-dev libtiff5-dev libudunits2-dev libgdal-dev libgeos-dev libproj-dev
+        run: sudo apt install libcurl4-openssl-dev libharfbuzz-dev libfribidi-dev libtiff5-dev libudunits2-dev libgdal-dev libgeos-dev libproj-dev libfontconfig1-dev
       - name: Determine R Library Location
         run: |
           R_LIBPATH=$( R -s -e "cat(.libPaths()[1L])" | xargs )

--- a/.github/workflows/inference-ci.yml
+++ b/.github/workflows/inference-ci.yml
@@ -58,7 +58,7 @@ jobs:
           r-version: ${{ matrix.R-version }}
           update-rtools: true
       - name: Install System Dependencies
-        run: sudo apt install libcurl4-openssl-dev libharfbuzz-dev libfribidi-dev libtiff5-dev libudunits2-dev libgdal-dev libgeos-dev libproj-dev
+        run: sudo apt install libcurl4-openssl-dev libharfbuzz-dev libfribidi-dev libtiff5-dev libudunits2-dev libgdal-dev libgeos-dev libproj-dev libfontconfig1-dev
       - name: Determine R Library Location
         run: |
           R_LIBPATH=$( R -s -e "cat(.libPaths()[1L])" | xargs )


### PR DESCRIPTION
**TLDR:** Add `libfontconfig1-dev` to ubuntu apt installs to fix issues with installing dependencies for R libraries with switch from ubuntu 22.04 to 24.04 for the default ubuntu runner.

@emprzy noticed some odd issues with the `inference CI` action while working on GH-428.

- Commit 6cc969629c4434f48c4167b977e678a8d2e74c8b passed the `inference CI` action with R 4.3.3, python 3.10, and ubuntu 22.04: https://github.com/HopkinsIDD/flepiMoP/actions/runs/12818975968/job/35745635662.
- Commit 148495a200bb7c23d627382761fa12420a96c004 fails the `inference CI` action with R 4.3.3, python 3.10, and ubuntu 24.04: https://github.com/HopkinsIDD/flepiMoP/actions/runs/12832048657/job/35785719411.

GitHub changed the ubuntu version for the `ubuntu-latest` runner recently (although, announced well in advance): https://github.com/actions/runner-images/issues/10636. The fix is to also install `libfontconfig1-dev` along with other apt packages. ~I'm in the process of manually running the `inference CI` and `flepicommon CI` actions on this branch to demonstrate the changes correct the issue.~ Below are links to the actions with a successful run on this branch with the update.

- `flepicommon CI`: https://github.com/HopkinsIDD/flepiMoP/actions/runs/12834071897
- `inference CI`: https://github.com/HopkinsIDD/flepiMoP/actions/runs/12834075973