### PR TITLE
Expand Scalar Likelihoods Manually In `Statistics.llik`

### DIFF
--- a/flepimop/gempyor_pkg/src/gempyor/statistics.py
+++ b/flepimop/gempyor_pkg/src/gempyor/statistics.py
@@ -287,6 +287,10 @@ class Statistic:
 
         # Use stored parameters in the distribution function call
         likelihood = dist_map[self.dist](gt_data, model_data, **self.params)
+        if len(likelihood.shape) == 0:
+            # If the likelihood is a scalar, broadcast it to the shape of the data.
+            # Xarray used to do this, but not anymore after numpy/numpy#26889?
+            likelihood = np.full(gt_data.shape, likelihood)
         likelihood = xr.DataArray(likelihood, coords=gt_data.coords, dims=gt_data.dims)
 
         return likelihood

--- a/flepimop/gempyor_pkg/tests/statistics/test_statistic_class.py
+++ b/flepimop/gempyor_pkg/tests/statistics/test_statistic_class.py
@@ -305,7 +305,7 @@ def simple_valid_factory_with_pois_with_some_zeros() -> MockStatisticInput:
 all_valid_factories = [
     (simple_valid_factory),
     (simple_valid_resample_factory),
-    (simple_valid_resample_factory),
+    (simple_valid_scale_factory),
     (simple_valid_resample_and_scale_factory),
     (simple_valid_factory_with_pois),
     (simple_valid_factory_with_pois_with_some_zeros),


### PR DESCRIPTION
### Describe your changes.

This pull request:

1. Corrects a duplicate test in b89ba91ccb53326ea54331fc1a2263ad555b4d1a, and
2. Expands scalar likelihoods to the expected shape in ce2ea2bbab4ee014758973079d7fadc89b89cc33.

(1) was just noticed as debugging, not the point of the hot fix, but (2) is to address unexpected `gempyor CI` failures when going from `numpy` v2.0.2 to v2.1.3. See:

1. Last successful run of the `gempyor CI` action: https://github.com/HopkinsIDD/flepiMoP/actions/runs/12790237550/job/35655537137.
2. Recent failure of the `gempyor CI` action: https://github.com/HopkinsIDD/flepiMoP/actions/runs/12932978266/job/36070486989.

The unexpected error comes from https://github.com/pydata/xarray/blob/10b68c33b1806d3a4be5e6fc3031962b1299a036/xarray/core/dataarray.py#L188 which is called by `xarray.DataArray.__init__`. The reason being is the call to https://github.com/pydata/xarray/blob/10b68c33b1806d3a4be5e6fc3031962b1299a036/xarray/core/dataarray.py#L219 (which is just before the call just cited) used to convert the `np.float64` into an `np.ndarray` at https://github.com/pydata/xarray/blob/10b68c33b1806d3a4be5e6fc3031962b1299a036/xarray/core/dataarray.py#L247. Between v2.0.2 and v.2.1.3 of numpy the '\_\_array_namespace\_\_' attr was introduced to `np.float64` which causes the `utils.is_scalar` call on https://github.com/pydata/xarray/blob/10b68c33b1806d3a4be5e6fc3031962b1299a036/xarray/core/dataarray.py#L230 to return `False` and now skips the expansion of the scalar value.

**Short description**: The `xarray` package used to expand `np.float64`s to match the shape given, but with the introduction of the '\_\_array_namespace\_\_' attr `xarray` no longer does so. Therefore the 'rmse' and 'absolute_error' likelihood distributions will fail unexpectedly. This PR manually expands likelihoods with no shape to match the expected shape.

### Does this pull request make any user interface changes? If so please describe.

The user interface changes are none. This PR restores the behavior prior to the recent numpy update.

### What does your pull request address? Tag relevant issues.

The recent unexpected failures of the `gempyor CI` action as reported by @emprzy when working on GH-468.