### PR TITLE
Consistent Xarray NaN To Int Coersion

### DIFF
--- a/flepimop/gempyor_pkg/src/gempyor/statistics.py
+++ b/flepimop/gempyor_pkg/src/gempyor/statistics.py
@@ -277,8 +277,9 @@ class Statistic:
                 f"Valid distributions: '{dist_map.keys()}'."
             )
         if self.dist in ["pois", "nbinom"]:
-            model_data = model_data.astype(int)
-            gt_data = gt_data.astype(int)
+            # pydata/xarray#4612
+            model_data = model_data.fillna(0.0).astype(int)
+            gt_data = gt_data.fillna(0.0).astype(int)
 
         if self.zero_to_one:
             # so confusing, wish I had not used xarray to do model_data[model_data==0]=1


### PR DESCRIPTION
### Describe your changes.

Some systems will coerce NaN values to int64 min (i.e. longleaf) whereas other systems will coerce NaN values to 0 (i.e. MacOS w/ M3). This enforces a consistent value of 0 for all systems for NaN values.

### Does this pull request make any user interface changes? If so please describe.

The user interface changes are a consistent 0 for NaN in the data when calculating the likelihood statistic. This change has not been documented anywhere yet. I think documenting this behavior and further improvements to NaN handling in `gempyor.statistics.Statistic` should be in a separate issue+PR(s).

### What does your pull request address? Tag relevant issues.

N/A

### Tag relevant team members.

@saraloo needs this sooner rather than later for work on disparities.