### PR TITLE
Requirements By Job Type And `BatchSystem.submit`

### DIFF
--- a/flepimop/gempyor_pkg/src/gempyor/batch.py
+++ b/flepimop/gempyor_pkg/src/gempyor/batch.py
@@ -347,12 +347,12 @@ def _submit_via_subprocess(
 
     if not exec.exists() or not exec.is_file():
         raise ValueError(
-            f"The script '{exec.absolute()}' either does not exist or is not a file."
+            f"The executable '{exec.absolute()}' either does not exist or is not a file."
         )
     if coerce_exec and not bool((current_perms := exec.stat().st_mode) & S_IXUSR):
         if logger is not None:
             logger.warning(
-                "The script '%s' is not executable, making it executable.", exec.absolute()
+                "The file '%s' is not executable, making it executable.", exec.absolute()
             )
         new_perms = current_perms | S_IXUSR
         exec.chmod(new_perms)
@@ -374,7 +374,7 @@ def _submit_via_subprocess(
     if exec_method == "popen":
         process = subprocess.Popen(cmd_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         process.wait(timeout=5 * 60)
-        stdout, stderr = process.communicate()
+        stdout, stderr = [comm.decode().strip() for comm in process.communicate()]
     else:
         process = subprocess.run(cmd_args, text=True, capture_output=True)
         stdout = process.stdout.strip()
@@ -392,7 +392,7 @@ def _submit_via_subprocess(
             logger.error("Captured stderr from executed script: %s", stderr)
 
     job_id = None if job_id_callback is None else job_id_callback(process)
-    if logger is not None:
+    if logger is not None and job_id is not None:
         logger.info("Extracted job ID of: %s", str(job_id))
 
     if exec_method == "popen":

--- a/flepimop/gempyor_pkg/src/gempyor/batch.py
+++ b/flepimop/gempyor_pkg/src/gempyor/batch.py
@@ -21,8 +21,8 @@ __all__ = (
 
 
 from abc import ABC, abstractmethod
+from collections.abc import Iterable
 from datetime import timedelta
-from enum import Enum, auto
 import json
 import math
 from pathlib import Path
@@ -490,7 +490,7 @@ class LocalBatchSystem(BatchSystem):
     def submit(
         self,
         script: Path,
-        options: dict[str, Any] | None = None,
+        options: dict[str, str | Iterable[str]] | None = None,
         verbosity: int | None = None,
         dry_run: bool = False,
     ) -> JobSubmission | None:
@@ -618,7 +618,7 @@ class SlurmBatchSystem(BatchSystem):
     def submit(
         self,
         script: Path,
-        options: dict[str, Any] | None = None,
+        options: dict[str, str | Iterable[str]] | None = None,
         verbosity: int | None = None,
         dry_run: bool = False,
     ) -> JobSubmission | None:

--- a/flepimop/gempyor_pkg/src/gempyor/batch.py
+++ b/flepimop/gempyor_pkg/src/gempyor/batch.py
@@ -166,7 +166,7 @@ class JobSize(BaseModel):
 
 def _job_resources_from_size_and_inference(
     job_size: JobSize,
-    inference: Literal["emcee"] | None,
+    inference: Literal["emcee", "r"],
     nodes: PositiveInt | None = None,
     cpus: PositiveInt | None = None,
     memory: PositiveInt | None = None,

--- a/flepimop/gempyor_pkg/src/gempyor/testing.py
+++ b/flepimop/gempyor_pkg/src/gempyor/testing.py
@@ -275,11 +275,12 @@ def sample_fits_distribution(
         return bool(np.greater(sample, 0.0))
 
 
-def sample_script(directory: Path, executable: bool) -> Path:
+def sample_script(name: str, directory: Path, executable: bool) -> Path:
     """
     Create a sample script for testing functions that require a script.
 
     Args:
+        name: The name of the script.
         directory: The directory to create the script in.
         executable: If the script should be executable.
 
@@ -287,13 +288,13 @@ def sample_script(directory: Path, executable: bool) -> Path:
         The path to the script.
 
     Notes:
-        The script is a simple bash script in a file named 'example' with contents:
+        The script is a simple bash script in a file named `name` with contents:
         ```bash
         #!/usr/bin/env bash
         echo 'Hello local!'
         ```
     """
-    script = directory / "example"
+    script = directory / name
     script.write_text("#!/usr/bin/env bash\necho 'Hello local!'")
     if executable:
         script.chmod(script.stat().st_mode | S_IXUSR)

--- a/flepimop/gempyor_pkg/src/gempyor/testing.py
+++ b/flepimop/gempyor_pkg/src/gempyor/testing.py
@@ -15,12 +15,14 @@ __all__ = [
     "sample_fits_distribution",
 ]
 
+
 from collections.abc import Generator
 import functools
 import os
+from pathlib import Path
+from stat import S_IXUSR
 from tempfile import TemporaryDirectory
 from typing import Any, Literal
-from pathlib import Path
 
 import confuse
 import numpy as np
@@ -271,3 +273,28 @@ def sample_fits_distribution(
         )
     elif distribution == "lognorm":
         return bool(np.greater(sample, 0.0))
+
+
+def sample_script(directory: Path, executable: bool) -> Path:
+    """
+    Create a sample script for testing functions that require a script.
+
+    Args:
+        directory: The directory to create the script in.
+        executable: If the script should be executable.
+
+    Returns:
+        The path to the script.
+
+    Notes:
+        The script is a simple bash script in a file named 'example' with contents:
+        ```bash
+        #!/usr/bin/env bash
+        echo 'Hello local!'
+        ```
+    """
+    script = directory / "example"
+    script.write_text("#!/usr/bin/env bash\necho 'Hello local!'")
+    if executable:
+        script.chmod(script.stat().st_mode | S_IXUSR)
+    return script

--- a/flepimop/gempyor_pkg/src/gempyor/testing.py
+++ b/flepimop/gempyor_pkg/src/gempyor/testing.py
@@ -275,14 +275,14 @@ def sample_fits_distribution(
         return bool(np.greater(sample, 0.0))
 
 
-def sample_script(name: str, directory: Path, executable: bool) -> Path:
+def sample_script(directory: Path, executable: bool, name: str = "example") -> Path:
     """
     Create a sample script for testing functions that require a script.
 
     Args:
-        name: The name of the script.
         directory: The directory to create the script in.
         executable: If the script should be executable.
+        name: The name of the script.
 
     Returns:
         The path to the script.

--- a/flepimop/gempyor_pkg/tests/batch/test__job_resources_from_size_and_inference.py
+++ b/flepimop/gempyor_pkg/tests/batch/test__job_resources_from_size_and_inference.py
@@ -36,9 +36,9 @@ def test_resources_is_constant_with_size_for_legacy(
     jobs: int, simulations: int, blocks: int
 ) -> None:
     size_1x = JobSize(jobs=jobs, simulations=simulations, blocks=blocks)
-    resources_1x = _job_resources_from_size_and_inference(size_1x, None)
+    resources_1x = _job_resources_from_size_and_inference(size_1x, "r")
     size_2x = JobSize(jobs=2 * jobs, simulations=2 * simulations, blocks=2 * blocks)
-    resources_2x = _job_resources_from_size_and_inference(size_2x, None)
+    resources_2x = _job_resources_from_size_and_inference(size_2x, "r")
     assert resources_2x.nodes >= 2 * resources_1x.nodes
     assert resources_2x.cpus == resources_1x.cpus
     assert resources_2x.memory == resources_1x.memory

--- a/flepimop/gempyor_pkg/tests/batch/test__job_resources_from_size_and_inference.py
+++ b/flepimop/gempyor_pkg/tests/batch/test__job_resources_from_size_and_inference.py
@@ -1,0 +1,44 @@
+import pytest
+
+from gempyor.batch import JobSize, _job_resources_from_size_and_inference
+
+
+@pytest.mark.parametrize("nodes", (2, 4, 8))
+def test_warning_for_more_than_one_node_with_emcee(nodes: int) -> None:
+    with pytest.warns(
+        UserWarning,
+        match=f"^EMCEE inference only supports 1 node given {nodes}, overriding.$",
+    ):
+        _job_resources_from_size_and_inference(
+            JobSize(jobs=10, simulations=200, blocks=1), "emcee", nodes=nodes
+        )
+
+
+@pytest.mark.parametrize("jobs", (5, 10, 20))
+@pytest.mark.parametrize("simulations", (100, 200, 400))
+@pytest.mark.parametrize("blocks", (1, 2, 4))
+def test_resources_scales_with_size_for_emcee(
+    jobs: int, simulations: int, blocks: int
+) -> None:
+    size_1x = JobSize(jobs=jobs, simulations=simulations, blocks=blocks)
+    resources_1x = _job_resources_from_size_and_inference(size_1x, "emcee")
+    size_2x = JobSize(jobs=2 * jobs, simulations=2 * simulations, blocks=2 * blocks)
+    resources_2x = _job_resources_from_size_and_inference(size_2x, "emcee")
+    assert resources_1x.nodes == resources_2x.nodes == 1
+    assert resources_2x.cpus >= 2 * resources_1x.cpus
+    assert resources_2x.memory >= 2 * resources_1x.memory
+
+
+@pytest.mark.parametrize("jobs", (5, 10, 20))
+@pytest.mark.parametrize("simulations", (100, 200, 400))
+@pytest.mark.parametrize("blocks", (1, 2, 4))
+def test_resources_is_constant_with_size_for_legacy(
+    jobs: int, simulations: int, blocks: int
+) -> None:
+    size_1x = JobSize(jobs=jobs, simulations=simulations, blocks=blocks)
+    resources_1x = _job_resources_from_size_and_inference(size_1x, None)
+    size_2x = JobSize(jobs=2 * jobs, simulations=2 * simulations, blocks=2 * blocks)
+    resources_2x = _job_resources_from_size_and_inference(size_2x, None)
+    assert resources_2x.nodes >= 2 * resources_1x.nodes
+    assert resources_2x.cpus == resources_1x.cpus
+    assert resources_2x.memory == resources_1x.memory

--- a/flepimop/gempyor_pkg/tests/batch/test__submit_via_subprocess.py
+++ b/flepimop/gempyor_pkg/tests/batch/test__submit_via_subprocess.py
@@ -71,7 +71,7 @@ def test_output_validation_for_select_values(
     stdout: str,
     stderr: str,
 ) -> None:
-    exec = sample_script(exec_name, tmp_path, exec_is_executable)
+    exec = sample_script(tmp_path, exec_is_executable, name=exec_name)
     logger = None if verbosity is None else get_script_logger(__name__, verbosity)
     job_id_callback = (
         (lambda proc: proc.pid)

--- a/flepimop/gempyor_pkg/tests/batch/test__submit_via_subprocess.py
+++ b/flepimop/gempyor_pkg/tests/batch/test__submit_via_subprocess.py
@@ -1,0 +1,167 @@
+from collections.abc import Iterable
+import logging
+import os
+from pathlib import Path
+import re
+from typing import Literal
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from gempyor.batch import JobSubmission, _submit_via_subprocess
+from gempyor.logging import get_script_logger
+from gempyor.testing import sample_script
+from gempyor.utils import _format_cli_options
+
+
+def test_exec_does_not_exist_or_is_not_a_file_value_error(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    does_not_exist = tmp_path / "nonexistent"
+    assert not does_not_exist.exists()
+    with pytest.raises(
+        ValueError,
+        match=(
+            f"^The executable '{does_not_exist.absolute()}' "
+            "either does not exist or is not a file.$"
+        ),
+    ):
+        _submit_via_subprocess(does_not_exist, False, "popen", None, None, None, None, True)
+
+    not_a_file = tmp_path / "not_a_file"
+    not_a_file.mkdir(parents=True, exist_ok=True)
+    assert not_a_file.is_dir()
+    with pytest.raises(
+        ValueError,
+        match=(
+            f"^The executable '{not_a_file.absolute()}' "
+            "either does not exist or is not a file.$"
+        ),
+    ):
+        _submit_via_subprocess(not_a_file, False, "popen", None, None, None, None, True)
+
+
+@pytest.mark.parametrize("exec_name", ("example",))
+@pytest.mark.parametrize("exec_is_executable", (True, False))
+@pytest.mark.parametrize("coerce_exec", (True, False))
+@pytest.mark.parametrize("exec_method", ("popen", "run"))
+@pytest.mark.parametrize("options", (None, {"output": "/abc/def/ghi.log", "ntasks": "2"}))
+@pytest.mark.parametrize("args", (None, ("/path/to/script",)))
+@pytest.mark.parametrize("use_job_id_callback", (True, False))
+@pytest.mark.parametrize("verbosity", (None, logging.DEBUG, logging.INFO, logging.WARNING))
+@pytest.mark.parametrize("dry_run", (True, False))
+@pytest.mark.parametrize("returncode", (0, 1))
+@pytest.mark.parametrize("stdout", ("Foobar", ""))
+@pytest.mark.parametrize("stderr", ("Error", ""))
+def test_output_validation_for_select_values(
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+    exec_name: str,
+    exec_is_executable: bool,
+    coerce_exec: bool,
+    exec_method: Literal["popen", "run"],
+    options: dict[str, str | Iterable[str]] | None,
+    args: Iterable[str] | None,
+    use_job_id_callback: bool,
+    verbosity: int | None,
+    dry_run: bool,
+    returncode: int,
+    stdout: str,
+    stderr: str,
+) -> None:
+    exec = sample_script(exec_name, tmp_path, exec_is_executable)
+    logger = None if verbosity is None else get_script_logger(__name__, verbosity)
+    job_id_callback = (
+        (lambda proc: proc.pid)
+        if exec_method == "popen"
+        else (lambda proc: int("".join(re.findall(r"\d+", proc.stdout) or ["-1"])))
+    )
+    with patch("gempyor.batch.subprocess.run") as subprocess_run_patch:
+        mock_completed_process = MagicMock()
+        mock_completed_process.returncode = returncode
+        mock_completed_process.stdout = stdout
+        mock_completed_process.stderr = stderr
+        subprocess_run_patch.return_value = mock_completed_process
+        with patch("gempyor.batch.subprocess.Popen") as subprocess_popen_patch:
+            mock_popened_process = MagicMock()
+            mock_popened_process.returncode = returncode
+            mock_popened_process.pid = 123
+            mock_popened_process.communicate.return_value = (
+                f"{stdout}\n".encode(),
+                f"{stderr}\n".encode(),
+            )
+            subprocess_popen_patch.return_value = mock_popened_process
+
+            result = _submit_via_subprocess(
+                exec,
+                coerce_exec,
+                exec_method,
+                options,
+                args,
+                job_id_callback if use_job_id_callback else None,
+                logger,
+                dry_run,
+            )
+            assert result is None if dry_run else isinstance(result, JobSubmission)
+
+            assert os.access(exec.absolute(), os.X_OK) == (
+                True if coerce_exec else exec_is_executable
+            )
+
+            call_args = None
+            if dry_run:
+                subprocess_run_patch.assert_not_called()
+                subprocess_popen_patch.assert_not_called()
+            elif exec_method == "popen":
+                subprocess_run_patch.assert_not_called()
+                subprocess_popen_patch.assert_called_once()
+                call_args = subprocess_popen_patch.call_args.args[0]
+            else:
+                subprocess_run_patch.assert_called_once()
+                subprocess_popen_patch.assert_not_called()
+                call_args = subprocess_run_patch.call_args.args[0]
+
+            if call_args is not None:
+                assert len(call_args) == 1 + sum(
+                    [1 if isinstance(v, str) else len(v) for v in (options or {}).values()]
+                ) + len(args or [])
+                assert Path(call_args[0]) == exec.absolute()
+                if options:
+                    assert call_args[
+                        1 : len(call_args) - len(args or [])
+                    ] == _format_cli_options(options)
+                if args:
+                    assert call_args[-len(args) :] == list(args)
+
+            if result is not None:
+                job_id = 123 if exec_method == "popen" else -1
+                assert result.job_id == (job_id if use_job_id_callback else None)
+                assert result.stdout == stdout
+                assert result.stderr == stderr
+                assert result.returncode == returncode
+
+            # Calculate the number of logs
+            log_count = 0
+            if verbosity is not None:
+                if verbosity <= logging.DEBUG:
+                    log_count += 1
+                if (
+                    coerce_exec and not exec_is_executable
+                ) and verbosity <= logging.WARNING:
+                    log_count += 1
+                if dry_run and verbosity <= logging.INFO:
+                    log_count += 1
+                elif not dry_run:
+                    if verbosity <= logging.INFO:
+                        log_count += 1
+                    if returncode != 0 and verbosity <= logging.CRITICAL:
+                        log_count += 1
+                    if verbosity <= logging.DEBUG and stdout:
+                        log_count += 1
+                    if verbosity <= logging.ERROR and stderr:
+                        log_count += 1
+                    if use_job_id_callback and verbosity <= logging.INFO:
+                        log_count += 1
+            assert len(caplog.records) == log_count

--- a/flepimop/gempyor_pkg/tests/batch/test_local_batch_system.py
+++ b/flepimop/gempyor_pkg/tests/batch/test_local_batch_system.py
@@ -1,9 +1,6 @@
-from datetime import timedelta
 import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-import subprocess
-import sys
 
 import pytest
 
@@ -101,7 +98,7 @@ def test_local_submit(
     dry_run: bool,
 ) -> None:
     batch_system = get_batch_system("local")
-    script = sample_script("example", tmp_path, executable)
+    script = sample_script(tmp_path, executable)
 
     with patch("gempyor.batch.subprocess.Popen") as subprocess_popen_patch:
         mock_process = MagicMock()

--- a/flepimop/gempyor_pkg/tests/batch/test_local_batch_system.py
+++ b/flepimop/gempyor_pkg/tests/batch/test_local_batch_system.py
@@ -101,7 +101,7 @@ def test_local_submit(
     dry_run: bool,
 ) -> None:
     batch_system = get_batch_system("local")
-    script = sample_script(tmp_path, executable)
+    script = sample_script("example", tmp_path, executable)
 
     with patch("gempyor.batch.subprocess.Popen") as subprocess_popen_patch:
         mock_process = MagicMock()
@@ -121,9 +121,9 @@ def test_local_submit(
 
         log_messages_by_level = {
             hash((logging.DEBUG, True)): 2,
-            hash((logging.DEBUG, False)): 3,
+            hash((logging.DEBUG, False)): 4,
             hash((logging.INFO, True)): 1,
-            hash((logging.INFO, False)): 1,
+            hash((logging.INFO, False)): 2,
         }
         assert len(caplog.records) == log_messages_by_level.get(
             hash((verbosity, dry_run)), 0

--- a/flepimop/gempyor_pkg/tests/batch/test_local_batch_system.py
+++ b/flepimop/gempyor_pkg/tests/batch/test_local_batch_system.py
@@ -1,8 +1,14 @@
 from datetime import timedelta
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+import subprocess
+import sys
 
 import pytest
 
-from gempyor.batch import JobSize, LocalBatchSystem, get_batch_system
+from gempyor.batch import JobSize, JobSubmission, LocalBatchSystem, get_batch_system
+from gempyor.testing import sample_script
 
 
 def test_local_batch_system_registered_by_default() -> None:
@@ -82,3 +88,43 @@ def test_size_from_jobs_simulations_blocks_for_select_values(
             batch_system.size_from_jobs_simulations_blocks(jobs, simulations, blocks)
             == expected
         )
+
+
+@pytest.mark.parametrize("executable", (True, False))
+@pytest.mark.parametrize("verbosity", (None, logging.DEBUG, logging.INFO, logging.WARNING))
+@pytest.mark.parametrize("dry_run", (True, False))
+def test_local_submit(
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+    executable: bool,
+    verbosity: int,
+    dry_run: bool,
+) -> None:
+    batch_system = get_batch_system("local")
+    script = sample_script(tmp_path, executable)
+
+    with patch("gempyor.batch.subprocess.Popen") as subprocess_popen_patch:
+        mock_process = MagicMock()
+        mock_process.communicate.return_value = (b"Hello local\n", b"")
+        mock_process.returncode = 0
+        mock_process.args = [str(script.absolute())]
+        mock_process.pid = 12345
+        subprocess_popen_patch.return_value = mock_process
+
+        job_result = batch_system.submit(script, None, verbosity, dry_run)
+        assert job_result is None if dry_run else isinstance(job_result, JobSubmission)
+
+        if dry_run:
+            subprocess_popen_patch.assert_not_called()
+        else:
+            subprocess_popen_patch.assert_called_once()
+
+        log_messages_by_level = {
+            hash((logging.DEBUG, True)): 2,
+            hash((logging.DEBUG, False)): 3,
+            hash((logging.INFO, True)): 1,
+            hash((logging.INFO, False)): 1,
+        }
+        assert len(caplog.records) == log_messages_by_level.get(
+            hash((verbosity, dry_run)), 0
+        ) + (1 if not executable and verbosity is not None else 0)

--- a/flepimop/gempyor_pkg/tests/batch/test_register_batch_system.py
+++ b/flepimop/gempyor_pkg/tests/batch/test_register_batch_system.py
@@ -6,6 +6,9 @@ from gempyor.batch import BatchSystem, register_batch_system, _reset_batch_syste
 class TestBatchSystem(BatchSystem):
     name = "test"
 
+    def submit(self, script, options=None, verbosity=None, dry_run=False):
+        return None
+
 
 def test_registration_adds_batch_system() -> None:
     _reset_batch_systems()

--- a/flepimop/gempyor_pkg/tests/batch/test_slurm_batch_system.py
+++ b/flepimop/gempyor_pkg/tests/batch/test_slurm_batch_system.py
@@ -53,7 +53,7 @@ def test_time_limit_formatting_for_select_values(
         ({}, None),
         ({"time": "1:00:00", "mem": "2GB"}, "--time=1:00:00 --mem=2GB"),
         (
-            {"output": Path("/abc/def/ghi.log"), "ntasks": 2},
+            {"output": "/abc/def/ghi.log", "ntasks": "2"},
             "--output=/abc/def/ghi.log --ntasks=2",
         ),
         (

--- a/flepimop/gempyor_pkg/tests/batch/test_slurm_batch_system.py
+++ b/flepimop/gempyor_pkg/tests/batch/test_slurm_batch_system.py
@@ -1,8 +1,14 @@
 from datetime import timedelta
+import logging
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from gempyor.batch import JobResources, SlurmBatchSystem, get_batch_system
+from gempyor.batch import JobResources, JobSubmission, SlurmBatchSystem, get_batch_system
+from gempyor.logging import _get_logging_level
+from gempyor.testing import sample_script
 
 
 def test_slurm_batch_system_registered_by_default() -> None:
@@ -39,3 +45,71 @@ def test_time_limit_formatting_for_select_values(
 ) -> None:
     batch_system = get_batch_system("slurm")
     assert batch_system.format_time_limit(job_time_limit) == expected
+
+
+@pytest.mark.parametrize(
+    ("options", "expected_options"),
+    (
+        ({}, None),
+        ({"time": "1:00:00", "mem": "2GB"}, "--time=1:00:00 --mem=2GB"),
+        (
+            {"output": Path("/abc/def/ghi.log"), "ntasks": 2},
+            "--output=/abc/def/ghi.log --ntasks=2",
+        ),
+        (
+            {"J": "My Job Name", "e": "/path/to/error.log"},
+            "-J='My Job Name' -e=/path/to/error.log",
+        ),
+    ),
+)
+@pytest.mark.parametrize("verbosity", (None, logging.DEBUG, logging.INFO, logging.WARNING))
+@pytest.mark.parametrize("dry_run", (True, False))
+def test_output_validation(
+    caplog: pytest.LogCaptureFixture,
+    tmp_path: Path,
+    options: dict[str, Any],
+    expected_options: str | None,
+    verbosity: int | None,
+    dry_run: bool,
+) -> None:
+    batch_system = get_batch_system("slurm")
+    script = sample_script(tmp_path, False)
+
+    with patch("gempyor.batch._shutil_which") as shutil_which_patch:
+        shutil_which_patch.return_value = "sbatch"
+        with patch("gempyor.batch.subprocess.run") as subprocess_run_patch:
+            mock_process = MagicMock()
+            mock_process.returncode = 0
+            mock_process.args = ["sbatch", str(script.absolute())]
+            mock_process.stdout = "Submitted batch job 999"
+            mock_process.stderr = ""
+            subprocess_run_patch.return_value = mock_process
+
+            job_result = batch_system.submit(script, options, verbosity, dry_run)
+            assert job_result is None if dry_run else isinstance(job_result, JobSubmission)
+
+            shutil_which_patch.assert_called_once_with("sbatch")
+            if dry_run:
+                subprocess_run_patch.assert_not_called()
+            else:
+                subprocess_run_patch.assert_called_once()
+
+            if verbosity is None:
+                assert len(caplog.records) == 0
+            else:
+                log_messages_by_level = {
+                    hash((logging.DEBUG, True)): 2,
+                    hash((logging.DEBUG, False)): 3,
+                    hash((logging.INFO, True)): 1,
+                    hash((logging.INFO, False)): 1,
+                }
+                assert len(caplog.records) == log_messages_by_level.get(
+                    hash((_get_logging_level(verbosity), dry_run)), 0
+                )
+
+            if not dry_run:
+                args: list[str] = subprocess_run_patch.call_args.args[0]
+                assert len(args) == 2 + len(options)
+                assert Path(args[-1]) == script.absolute()
+                if options:
+                    assert " ".join(args[1:-1]) == expected_options

--- a/flepimop/gempyor_pkg/tests/batch/test_slurm_batch_system.py
+++ b/flepimop/gempyor_pkg/tests/batch/test_slurm_batch_system.py
@@ -73,14 +73,15 @@ def test_output_validation(
     dry_run: bool,
 ) -> None:
     batch_system = get_batch_system("slurm")
-    script = sample_script(tmp_path, False)
+    sbatch = str(sample_script("sbatch", tmp_path, True).absolute())
+    script = sample_script("run.sbatch", tmp_path, False)
 
     with patch("gempyor.batch._shutil_which") as shutil_which_patch:
-        shutil_which_patch.return_value = "sbatch"
+        shutil_which_patch.return_value = sbatch
         with patch("gempyor.batch.subprocess.run") as subprocess_run_patch:
             mock_process = MagicMock()
             mock_process.returncode = 0
-            mock_process.args = ["sbatch", str(script.absolute())]
+            mock_process.args = [sbatch, str(script.absolute())]
             mock_process.stdout = "Submitted batch job 999"
             mock_process.stderr = ""
             subprocess_run_patch.return_value = mock_process
@@ -99,9 +100,9 @@ def test_output_validation(
             else:
                 log_messages_by_level = {
                     hash((logging.DEBUG, True)): 2,
-                    hash((logging.DEBUG, False)): 3,
+                    hash((logging.DEBUG, False)): 4,
                     hash((logging.INFO, True)): 1,
-                    hash((logging.INFO, False)): 1,
+                    hash((logging.INFO, False)): 2,
                 }
                 assert len(caplog.records) == log_messages_by_level.get(
                     hash((_get_logging_level(verbosity), dry_run)), 0

--- a/flepimop/gempyor_pkg/tests/batch/test_slurm_batch_system.py
+++ b/flepimop/gempyor_pkg/tests/batch/test_slurm_batch_system.py
@@ -73,8 +73,8 @@ def test_output_validation(
     dry_run: bool,
 ) -> None:
     batch_system = get_batch_system("slurm")
-    sbatch = str(sample_script("sbatch", tmp_path, True).absolute())
-    script = sample_script("run.sbatch", tmp_path, False)
+    sbatch = str(sample_script(tmp_path, True, name="sbatch").absolute())
+    script = sample_script(tmp_path, False, name="run.sbatch")
 
     with patch("gempyor.batch._shutil_which") as shutil_which_patch:
         shutil_which_patch.return_value = sbatch

--- a/flepimop/gempyor_pkg/tests/utils/test__format_cli_options.py
+++ b/flepimop/gempyor_pkg/tests/utils/test__format_cli_options.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from gempyor.utils import _format_cli_options
+
+
+@pytest.mark.parametrize("options", ({"name": "foo"},))
+@pytest.mark.parametrize("always_single", (True, False))
+def test_affect_of_always_single(options: dict[str, Any], always_single: bool) -> None:
+    formatted_options = _format_cli_options(options, always_single=always_single)
+    assert all(fo.startswith("-") for fo in formatted_options)
+    assert (
+        all(not fo.startswith("--") for fo in formatted_options)
+        if always_single
+        else any(fo.startswith("--") for fo in formatted_options)
+    )
+
+
+@pytest.mark.parametrize(
+    ("options", "always_single", "formatted_options"),
+    (
+        ({}, False, []),
+        ({}, True, []),
+        (None, False, []),
+        (None, True, []),
+        ({"name": "foo bar fizz buzz"}, False, ["--name='foo bar fizz buzz'"]),
+        ({"name": "foo bar fizz buzz"}, True, ["-name='foo bar fizz buzz'"]),
+        ({"o": Path("/path/to/output.log")}, False, ["-o=/path/to/output.log"]),
+        ({"o": Path("/path/to/output.log")}, True, ["-o=/path/to/output.log"]),
+        (
+            {"opt1": "```", "opt2": "$( echo 'Hello!')"},
+            False,
+            ["--opt1='```'", "--opt2='$( echo '\"'\"'Hello!'\"'\"')'"],
+        ),
+        (
+            {"opt1": "```", "opt2": "$( echo 'Hello!')"},
+            True,
+            ["-opt1='```'", "-opt2='$( echo '\"'\"'Hello!'\"'\"')'"],
+        ),
+        (
+            {"start": datetime(2024, 1, 1, 12, 34, 56), "J": "rm -rf ~"},
+            False,
+            ["--start='2024-01-01 12:34:56'", "-J='rm -rf ~'"],
+        ),
+        (
+            {"start": datetime(2024, 1, 1, 12, 34, 56), "J": "rm -rf ~"},
+            True,
+            ["-start='2024-01-01 12:34:56'", "-J='rm -rf ~'"],
+        ),
+    ),
+)
+def test_output_validation_for_select_values(
+    options: dict[str, Any] | None, always_single: bool, formatted_options: list[str]
+) -> None:
+    assert _format_cli_options(options, always_single=always_single) == formatted_options

--- a/flepimop/gempyor_pkg/tests/utils/test__format_cli_options.py
+++ b/flepimop/gempyor_pkg/tests/utils/test__format_cli_options.py
@@ -1,6 +1,4 @@
-from datetime import datetime
-from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 import pytest
 
@@ -19,40 +17,160 @@ def test_affect_of_always_single(options: dict[str, Any], always_single: bool) -
     )
 
 
+@pytest.mark.parametrize("options", ({}, None))
+@pytest.mark.parametrize("always_single", (True, False))
+@pytest.mark.parametrize("iterable_formatting", ("split", "comma"))
+def test_output_validation_for_empty_values(
+    options: dict[str, Any] | None,
+    always_single: bool,
+    iterable_formatting: Literal["split", "comma"],
+) -> None:
+    assert (
+        _format_cli_options(
+            options, always_single=always_single, iterable_formatting=iterable_formatting
+        )
+        == []
+    )
+
+
 @pytest.mark.parametrize(
-    ("options", "always_single", "formatted_options"),
+    ("options", "always_single", "iterable_formatting", "formatted_options"),
     (
-        ({}, False, []),
-        ({}, True, []),
-        (None, False, []),
-        (None, True, []),
-        ({"name": "foo bar fizz buzz"}, False, ["--name='foo bar fizz buzz'"]),
-        ({"name": "foo bar fizz buzz"}, True, ["-name='foo bar fizz buzz'"]),
-        ({"o": Path("/path/to/output.log")}, False, ["-o=/path/to/output.log"]),
-        ({"o": Path("/path/to/output.log")}, True, ["-o=/path/to/output.log"]),
+        ({"name": "foo bar fizz buzz"}, False, "split", ["--name='foo bar fizz buzz'"]),
+        ({"name": "foo bar fizz buzz"}, True, "split", ["-name='foo bar fizz buzz'"]),
+        ({"o": "/path/to/output.log"}, False, "split", ["-o=/path/to/output.log"]),
+        ({"o": "/path/to/output.log"}, True, "split", ["-o=/path/to/output.log"]),
         (
             {"opt1": "```", "opt2": "$( echo 'Hello!')"},
             False,
+            "split",
             ["--opt1='```'", "--opt2='$( echo '\"'\"'Hello!'\"'\"')'"],
         ),
         (
             {"opt1": "```", "opt2": "$( echo 'Hello!')"},
             True,
+            "split",
             ["-opt1='```'", "-opt2='$( echo '\"'\"'Hello!'\"'\"')'"],
         ),
         (
-            {"start": datetime(2024, 1, 1, 12, 34, 56), "J": "rm -rf ~"},
+            {"start": "2024-01-01 12:34:56", "J": "rm -rf ~"},
             False,
+            "split",
             ["--start='2024-01-01 12:34:56'", "-J='rm -rf ~'"],
         ),
         (
-            {"start": datetime(2024, 1, 1, 12, 34, 56), "J": "rm -rf ~"},
+            {"start": "2024-01-01 12:34:56", "J": "rm -rf ~"},
             True,
+            "split",
             ["-start='2024-01-01 12:34:56'", "-J='rm -rf ~'"],
+        ),
+        (
+            {"opt1": ["foo", "bar", "fizz", "buzz"]},
+            False,
+            "split",
+            ["--opt1=foo", "--opt1=bar", "--opt1=fizz", "--opt1=buzz"],
+        ),
+        (
+            {"opt1": ["foo", "bar", "fizz", "buzz"]},
+            False,
+            "comma",
+            ["--opt1=foo,bar,fizz,buzz"],
+        ),
+        (
+            {"opt1": ["foo", "bar", "fizz", "buzz"]},
+            True,
+            "split",
+            ["-opt1=foo", "-opt1=bar", "-opt1=fizz", "-opt1=buzz"],
+        ),
+        (
+            {"opt1": ["foo", "bar", "fizz", "buzz"]},
+            True,
+            "comma",
+            ["-opt1=foo,bar,fizz,buzz"],
+        ),
+        (
+            {
+                "letters": ["abc", "def", "ghi"],
+                "numbers": ["1", "2", "3"],
+                "symbols": "!@#",
+                "cmd": "echo $( cat foobar.txt | grep -v 'baz' )",
+            },
+            False,
+            "split",
+            [
+                "--letters=abc",
+                "--letters=def",
+                "--letters=ghi",
+                "--numbers=1",
+                "--numbers=2",
+                "--numbers=3",
+                "--symbols='!@#'",
+                """--cmd=\'echo $( cat foobar.txt | grep -v \'"\'"\'baz\'"\'"\' )\'""",
+            ],
+        ),
+        (
+            {
+                "letters": ["abc", "def", "ghi"],
+                "numbers": ["1", "2", "3"],
+                "symbols": "!@#",
+                "cmd": "echo $( cat foobar.txt | grep -v 'baz' )",
+            },
+            True,
+            "split",
+            [
+                "-letters=abc",
+                "-letters=def",
+                "-letters=ghi",
+                "-numbers=1",
+                "-numbers=2",
+                "-numbers=3",
+                "-symbols='!@#'",
+                """-cmd=\'echo $( cat foobar.txt | grep -v \'"\'"\'baz\'"\'"\' )\'""",
+            ],
+        ),
+        (
+            {
+                "letters": ["abc", "def", "ghi"],
+                "numbers": ["1", "2", "3"],
+                "symbols": "!@#",
+                "cmd": "echo $( cat foobar.txt | grep -v 'baz' )",
+            },
+            False,
+            "comma",
+            [
+                "--letters=abc,def,ghi",
+                "--numbers=1,2,3",
+                "--symbols='!@#'",
+                """--cmd=\'echo $( cat foobar.txt | grep -v \'"\'"\'baz\'"\'"\' )\'""",
+            ],
+        ),
+        (
+            {
+                "letters": ["abc", "def", "ghi"],
+                "numbers": ["1", "2", "3"],
+                "symbols": "!@#",
+                "cmd": "echo $( cat foobar.txt | grep -v 'baz' )",
+            },
+            True,
+            "comma",
+            [
+                "-letters=abc,def,ghi",
+                "-numbers=1,2,3",
+                "-symbols='!@#'",
+                """-cmd=\'echo $( cat foobar.txt | grep -v \'"\'"\'baz\'"\'"\' )\'""",
+            ],
         ),
     ),
 )
 def test_output_validation_for_select_values(
-    options: dict[str, Any] | None, always_single: bool, formatted_options: list[str]
+    options: dict[str, Any] | None,
+    always_single: bool,
+    iterable_formatting: Literal["split", "comma"],
+    formatted_options: list[str],
 ) -> None:
-    assert _format_cli_options(options, always_single=always_single) == formatted_options
+    assert (
+        _format_cli_options(
+            options, always_single=always_single, iterable_formatting=iterable_formatting
+        )
+        == formatted_options
+    )


### PR DESCRIPTION
### Describe your changes.

This pull request:

- Adds internal `_job_resources_from_size_and_inference` to give a default `JobResources` from `JobSize` and inference method name*,
- Adds abstract method `BatchSystem.submit` to submit jobs to a batch system which can return a `JobSubmission` which is a thin extension of `subprocess.CompletedProcess` with a `job_id` attribute,
- Implemented `submit` for `LocalBatchSystem` and `SlurmBatchSystem`,
- Adds `_format_cli_options` to `gempyor.utils` for formatting CLI arguments,
- Adds a light testing utility `sample_script`.

*There were discussions of creating a `JobType` ABC and have EMCEE and legacy implement this and then add this method to that (similar to `BatchSystem`). I decided against this to 1) develop the MVP faster, and 2) I think this method would have to be added to both the simulator and inference ABCs (see GH-402 & GH-432 respectively), because the inference method would have to call the simulator one and use that result in it's own calculation.

### Does this pull request make any user interface changes? If so please describe.

The user interface changes are some API changes to `gempyor.batch` which have been documented in docstrings, has not been documented in GitBook yet. I think documenting there is more appropriate once further along in the product.

### What does your pull request address? Tag relevant issues.

This pull request addresses GH-487, spun out of GH-394. After this PR will be actually creating the `flepimop submit` CLI action using all of this infrastructure.