### PR TITLE
fix issue: seeding is incorrect when there are more subpop in the seeding file than in ModelInfo

### DIFF
--- a/flepimop/gempyor_pkg/src/gempyor/seeding.py
+++ b/flepimop/gempyor_pkg/src/gempyor/seeding.py
@@ -16,6 +16,9 @@ logger = logging.getLogger(__name__)
 
 
 def _DataFrame2NumbaDict(df, amounts, modinf) -> nb.typed.Dict:
+    # This functions is extremely unsafe and should only be used after the dataframe has
+    # been filtered on dates and subpop according to the limits sets in `modinf`. And
+    # sorted by date.
     if not df["date"].is_monotonic_increasing:
         raise ValueError("The `df` given is not sorted by the 'date' column.")
 
@@ -138,12 +141,15 @@ class Seeding(SimulationComponent):
 
         # Sorting by date is very important here for the seeding format necessary !!!!
         # print(seeding.shape)
-        seeding = seeding.sort_values(by="date", axis="index").reset_index()
+        seeding = seeding.sort_values(by="date", axis="index").reset_index(drop=True)
         # print(seeding)
         mask = (seeding["date"].dt.date > modinf.ti) & (
             seeding["date"].dt.date <= modinf.tf
         )
-        seeding = seeding.loc[mask].reset_index()
+        seeding = seeding.loc[mask].reset_index(drop=True)
+        mask = seeding["subpop"].isin(modinf.subpop_struct.subpop_names)
+        seeding = seeding.loc[mask].reset_index(drop=True)
+
         # print(seeding.shape)
         # print(seeding)
 


### PR DESCRIPTION
In commit https://github.com/HopkinsIDD/flepiMoP/commit/307401a855035918dc928c8104eb0decef80b4fb we authorized the seeding file to contain reference to more subpops than there is in modelInfo. This is useful when using `subpop: selected`, but not only (and was introduced before `subpop: selected`. 

This change created a bug. When the seeding file contains more subpop than there is in model info, these additional subpop still increment an index that is incremented for each row of the dataframe, breaking seeding structure.

### Describe your changes.

We already had a seeding bug like this at the time but with the dates that are not between ti and tf, and wanted to make a safe `_DataFrame2NumbaDict` but we went for the fast and dirty fix (issue #114 , PR #121 ). In the same vein, this instead of being a proper fix making `_DataFrame2NumbaDict` safe, just filter the seeding file before the only call to that function. First by date (from issue #114 , PR #121) then by subpop (to fix the current bug in disparities).

@TimothyWillard : Should I add a unit test ? The function `_DataFrame2NumbaDict` is still incredibly unsafe so that will require to test the two functions in combination.

Link to slack conversion about it: 
https://iddynamicsjhu.slack.com/archives/CU0SBC2AC/p1738603638164729?thread_ts=1738594938.991539&cid=CU0SBC2AC


Since this bug is there since March, hard to tell what has been affected. But one can guess this was rare before the  `subpop: selected` features, and this was added this summer. Since then, Disparities round 1 was not affected because it modeled the two states together, and Flu was not affected because there was (afaik) no seeding)
