### PR TITLE
Making all import statements with in `gempyor` PEP8 compliant.

### DIFF
--- a/flepimop/gempyor_pkg/src/gempyor/NPI/__init__.py
+++ b/flepimop/gempyor_pkg/src/gempyor/NPI/__init__.py
@@ -1,10 +1,10 @@
-from pathlib import Path
-import sys
 import inspect
 import pkgutil
+import sys
 from importlib import import_module
-from .helpers import *
+from pathlib import Path
 
+from . import helpers
 from .base import NPIBase
 
 __all__ = ["NPIBase"]

--- a/flepimop/gempyor_pkg/src/gempyor/NPI/base.py
+++ b/flepimop/gempyor_pkg/src/gempyor/NPI/base.py
@@ -1,8 +1,8 @@
 import abc
 import datetime
 
-import pyarrow as pa
 import click
+import pyarrow as pa
 
 from ..shared_cli import cli
 

--- a/flepimop/gempyor_pkg/src/gempyor/_click.py
+++ b/flepimop/gempyor_pkg/src/gempyor/_click.py
@@ -4,9 +4,8 @@ __all__ = []
 from datetime import timedelta
 from math import ceil
 import re
-from typing import Any, Literal
-
 import click
+from typing import Any, Literal
 
 
 class DurationParamType(click.ParamType):

--- a/flepimop/gempyor_pkg/src/gempyor/batch.py
+++ b/flepimop/gempyor_pkg/src/gempyor/batch.py
@@ -24,10 +24,10 @@ from datetime import timedelta
 from enum import Enum, auto
 import json
 import math
-from pathlib import Path
 import sys
-from typing import Any, Literal, overload
 import warnings
+from pathlib import Path
+from typing import Any, Literal, overload
 
 from pydantic import BaseModel, PositiveInt
 

--- a/flepimop/gempyor_pkg/src/gempyor/calibrate.py
+++ b/flepimop/gempyor_pkg/src/gempyor/calibrate.py
@@ -8,11 +8,11 @@ Functions:
 """
 
 #!/usr/bin/env python
-import os
-import shutil
 import copy
-import pathlib
 import multiprocessing
+import os
+import pathlib
+import shutil
 
 import click
 import emcee
@@ -21,8 +21,8 @@ import numpy as np
 import gempyor
 from gempyor import model_info, file_paths, config, inference_parameter
 from gempyor.inference import GempyorInference
+from gempyor.postprocess_inference import *
 from gempyor.utils import config, as_list
-import gempyor.postprocess_inference
 
 
 # from .profile import profile_options

--- a/flepimop/gempyor_pkg/src/gempyor/cli.py
+++ b/flepimop/gempyor_pkg/src/gempyor/cli.py
@@ -2,13 +2,14 @@ import click
 import yaml
 
 from .shared_cli import (
-    config_files_argument,
-    config_file_options,
-    parse_config_files,
     cli,
+    config_file_options,
+    config_files_argument,
     mock_context,
+    parse_config_files,
 )
-from .utils import _dump_formatted_yaml, config
+
+from .utils import config, _dump_formatted_yaml
 
 # register the commands from the other modules
 from . import compartments, simulate

--- a/flepimop/gempyor_pkg/src/gempyor/compartments.py
+++ b/flepimop/gempyor_pkg/src/gempyor/compartments.py
@@ -18,14 +18,14 @@ import logging
 from functools import reduce
 from typing import Any
 
+import click
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
-from click import pass_context, Context
 
-from .utils import config, Timer, as_list
-from .shared_cli import config_files_argument, config_file_options, parse_config_files, cli
+from .shared_cli import cli, config_file_options, config_files_argument, parse_config_files
+from .utils import Timer, as_list, config
 
 logger = logging.getLogger(__name__)
 

--- a/flepimop/gempyor_pkg/src/gempyor/compartments.py
+++ b/flepimop/gempyor_pkg/src/gempyor/compartments.py
@@ -18,11 +18,11 @@ import logging
 from functools import reduce
 from typing import Any
 
-import click
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
+from click import pass_context, Context
 
 from .shared_cli import cli, config_file_options, config_files_argument, parse_config_files
 from .utils import Timer, as_list, config

--- a/flepimop/gempyor_pkg/src/gempyor/config_validator.py
+++ b/flepimop/gempyor_pkg/src/gempyor/config_validator.py
@@ -1,15 +1,17 @@
 import yaml
+from datetime import date
+from functools import partial
+from typing import Any, Annotated, Dict, List, Literal, Optional, Union
+
 from pydantic import (
+    AfterValidator,
     BaseModel,
+    Field,
     ValidationError,
     model_validator,
-    Field,
-    AfterValidator,
     validator,
 )
-from datetime import date
-from typing import Dict, List, Union, Literal, Optional, Annotated, Any
-from functools import partial
+
 from gempyor import compartments
 
 

--- a/flepimop/gempyor_pkg/src/gempyor/dev/dev_outcome.py
+++ b/flepimop/gempyor_pkg/src/gempyor/dev/dev_outcome.py
@@ -1,36 +1,22 @@
-import numpy as np
-import os
-import pytest
-import warnings
-import shutil
-
-import pathlib
-import pyarrow as pa
-import pyarrow.parquet as pq
+import datetime
 import filecmp
-import pandas as pd
-import matplotlib.pyplot as plt
-import numpy as np
-import pandas as pd
-import datetime
+import glob
+import os
+import pathlib
+import shutil
+import sys
+import warnings
 
-import pytest
-
-from . import outcomes
-from .utils import config
-
-import pandas as pd
-import numpy as np
-import datetime
-import matplotlib.pyplot as plt
-import glob, os, sys
-from pathlib import Path
-
-# import seaborn as sns
-import pyarrow.parquet as pq
 import click
+import numpy as np
+import pandas as pd
 import pyarrow as pa
-from . import file_paths
+import pyarrow.parquet as pq
+import pytest
+import matplotlib.pyplot as plt
+
+from . import file_paths, outcomes
+from .utils import config
 
 config.clear()
 config.read(user=False)

--- a/flepimop/gempyor_pkg/src/gempyor/dev/dev_seir.py
+++ b/flepimop/gempyor_pkg/src/gempyor/dev/dev_seir.py
@@ -12,7 +12,7 @@ import pytest
 import matplotlib.pyplot as plt
 
 from . import compartments, NPI, file_paths, model_info, seir
-from .utils import config
+from ..utils import config
 
 DATA_DIR = "data"
 

--- a/flepimop/gempyor_pkg/src/gempyor/dev/dev_seir.py
+++ b/flepimop/gempyor_pkg/src/gempyor/dev/dev_seir.py
@@ -1,17 +1,17 @@
-import numpy as np
 import os
-import pytest
-import warnings
 import shutil
-
+import warnings
+import filecmp
 import pathlib
+
+import numpy as np
+import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
-import filecmp
-import pandas as pd
+import pytest
 import matplotlib.pyplot as plt
-from . import compartments, seir, NPI, file_paths, model_info
 
+from . import compartments, NPI, file_paths, model_info, seir
 from .utils import config
 
 DATA_DIR = "data"

--- a/flepimop/gempyor_pkg/src/gempyor/dev/steps.py
+++ b/flepimop/gempyor_pkg/src/gempyor/dev/steps.py
@@ -1,8 +1,9 @@
 import numpy as np
-from scipy.integrate import solve_ivp, odeint, ode
-from numba import jit
 import numba
+from numba import jit
 import tqdm
+from scipy.integrate import solve_ivp, odeint, ode
+
 from ..utils import Timer
 
 (

--- a/flepimop/gempyor_pkg/src/gempyor/inference.py
+++ b/flepimop/gempyor_pkg/src/gempyor/inference.py
@@ -30,23 +30,22 @@ Functions:
         parameters based on this info. Returns the reduced parameters.
 """
 
-import os
-import logging
 import copy
+import logging
+import os
 import multiprocessing as mp
 from concurrent.futures import ProcessPoolExecutor
 
 import numpy as np
 import pandas as pd
 import pyarrow.parquet as pq
-import xarray as xr
 import numba as nb
+import xarray as xr
 
 from typing import Literal
 
-from . import seir, model_info
-from . import outcomes, file_paths
-from .utils import config, Timer, read_df, as_list
+from . import file_paths, model_info, outcomes, seir
+from .utils import Timer, as_list, config, read_df
 
 
 logging.basicConfig(level=os.environ.get("FLEPI_LOGLEVEL", "INFO").upper())

--- a/flepimop/gempyor_pkg/src/gempyor/inference_parameter.py
+++ b/flepimop/gempyor_pkg/src/gempyor/inference_parameter.py
@@ -1,7 +1,8 @@
-import xarray as xr
-import pandas as pd
 import numpy as np
+import pandas as pd
+import xarray as xr
 import confuse
+
 from . import NPI
 
 

--- a/flepimop/gempyor_pkg/src/gempyor/info.py
+++ b/flepimop/gempyor_pkg/src/gempyor/info.py
@@ -45,15 +45,16 @@ Examples:
 __all__ = ["Cluster", "Module", "PathExport", "get_cluster_info"]
 
 
-from collections.abc import Iterable
 import os
-from pathlib import Path
 import re
+from pathlib import Path
 from socket import getfqdn
+from collections.abc import Iterable
 from typing import Pattern, TypeVar
 
-from pydantic import BaseModel
 import yaml
+
+from pydantic import BaseModel
 
 
 class Module(BaseModel):

--- a/flepimop/gempyor_pkg/src/gempyor/initial_conditions.py
+++ b/flepimop/gempyor_pkg/src/gempyor/initial_conditions.py
@@ -1,15 +1,16 @@
-from typing import Dict
+import logging
+import os
+import warnings
 
+import confuse
 import numpy as np
 import pandas as pd
 from numba.typed import Dict
-import confuse
-import logging
-from .simulation_component import SimulationComponent
+from typing import Dict as TypingDict
+
 from . import utils
+from .simulation_component import SimulationComponent
 from .utils import read_df
-import warnings
-import os
 
 logger = logging.getLogger(__name__)
 

--- a/flepimop/gempyor_pkg/src/gempyor/logloss.py
+++ b/flepimop/gempyor_pkg/src/gempyor/logloss.py
@@ -1,10 +1,12 @@
-import xarray as xr
-import pandas as pd
-import numpy as np
-import confuse
-import scipy.stats
-from . import statistics
 import os
+
+import confuse
+import numpy as np
+import pandas as pd
+import scipy.stats
+import xarray as xr
+
+from . import statistics
 
 
 ## https://docs.xarray.dev/en/stable/user-guide/indexing.html#assigning-values-with-indexing

--- a/flepimop/gempyor_pkg/src/gempyor/outcomes.py
+++ b/flepimop/gempyor_pkg/src/gempyor/outcomes.py
@@ -1,16 +1,16 @@
-import itertools
+import datetime
 import logging
-import time
+import os
+import pathlib
 
-from numba import jit
+import confuse
+import numba as nb
 import numpy as np
+import numpy.typing as npt
 import pandas as pd
-import pyarrow as pa
-import tqdm.contrib.concurrent
-import xarray as xr
 
-from .utils import config, Timer, read_df
-from . import NPI, model_info
+from . import compartments, file_paths, initial_conditions, parameters, seeding, subpopulation_structure
+from .utils import read_df, write_df
 
 
 logger = logging.getLogger(__name__)

--- a/flepimop/gempyor_pkg/src/gempyor/outcomes.py
+++ b/flepimop/gempyor_pkg/src/gempyor/outcomes.py
@@ -1,23 +1,16 @@
-import datetime
+import itertools
 import logging
-import os
-import pathlib
+import time
 
-import confuse
-import numba as nb
 import numpy as np
-import numpy.typing as npt
 import pandas as pd
+import pyarrow as pa
+import tqdm.contrib.concurrent
+import xarray as xr
+from numba import jit
 
-from . import (
-    compartments,
-    file_paths,
-    initial_conditions,
-    parameters,
-    seeding,
-    subpopulation_structure,
-)
-from .utils import read_df, write_df
+from .utils import config, Timer, read_df
+from . import NPI, model_info
 
 
 logger = logging.getLogger(__name__)

--- a/flepimop/gempyor_pkg/src/gempyor/outcomes.py
+++ b/flepimop/gempyor_pkg/src/gempyor/outcomes.py
@@ -9,7 +9,14 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
-from . import compartments, file_paths, initial_conditions, parameters, seeding, subpopulation_structure
+from . import (
+    compartments,
+    file_paths,
+    initial_conditions,
+    parameters,
+    seeding,
+    subpopulation_structure,
+)
 from .utils import read_df, write_df
 
 

--- a/flepimop/gempyor_pkg/src/gempyor/postprocess_inference.py
+++ b/flepimop/gempyor_pkg/src/gempyor/postprocess_inference.py
@@ -1,5 +1,6 @@
-from matplotlib.backends.backend_pdf import PdfPages
 import matplotlib.pyplot as plt
+from matplotlib.backends.backend_pdf import PdfPages
+
 import numpy as np
 import seaborn as sns
 import tqdm

--- a/flepimop/gempyor_pkg/src/gempyor/seeding.py
+++ b/flepimop/gempyor_pkg/src/gempyor/seeding.py
@@ -3,10 +3,10 @@ __all__ = ("Seeding", "SeedingFactory")
 
 
 # Imports
-from datetime import date
 import logging
-from typing import Any
 import warnings
+from datetime import date
+from typing import Any
 
 import confuse
 import numba as nb
@@ -14,10 +14,10 @@ import numpy as np
 import numpy.typing as npt
 import pandas as pd
 
+from . import utils
 from .compartments import Compartments
 from .simulation_component import SimulationComponent
 from .subpopulation_structure import SubpopulationStructure
-from . import utils
 
 
 # Globals

--- a/flepimop/gempyor_pkg/src/gempyor/shared_cli.py
+++ b/flepimop/gempyor_pkg/src/gempyor/shared_cli.py
@@ -8,15 +8,16 @@ __all__ = []
 
 import multiprocessing
 import pathlib
-
-from typing import Any, Callable
 import warnings
 
 import click
 import confuse
 
+from typing import Any, Callable
+
+from . import utils
 from .logging import get_script_logger
-from .utils import config, as_list
+from .utils import as_list, config
 
 
 @click.group()

--- a/flepimop/gempyor_pkg/src/gempyor/simulate.py
+++ b/flepimop/gempyor_pkg/src/gempyor/simulate.py
@@ -156,23 +156,18 @@
 
 ## @cond
 
-import time, warnings, sys
+import sys
+import time
+import warnings
 
-from pathlib import Path
 from collections.abc import Iterable
+from pathlib import Path
 
-from confuse import Configuration
 from click import Context, pass_context
+from confuse import Configuration
 
-from . import seir, outcomes, model_info, utils
-from .shared_cli import (
-    config_files_argument,
-    config_file_options,
-    parse_config_files,
-    cli,
-    click_helpstring,
-    mock_context,
-)
+from . import model_info, outcomes, seir, utils
+from .shared_cli import cli, click_helpstring, config_file_options, config_files_argument, mock_context, parse_config_files
 
 # from .profile import profile_options
 

--- a/flepimop/gempyor_pkg/src/gempyor/simulate.py
+++ b/flepimop/gempyor_pkg/src/gempyor/simulate.py
@@ -167,7 +167,14 @@ from click import Context, pass_context
 from confuse import Configuration
 
 from . import model_info, outcomes, seir, utils
-from .shared_cli import cli, click_helpstring, config_file_options, config_files_argument, mock_context, parse_config_files
+from .shared_cli import (
+    cli,
+    click_helpstring,
+    config_file_options,
+    config_files_argument,
+    mock_context,
+    parse_config_files,
+)
 
 # from .profile import profile_options
 

--- a/flepimop/gempyor_pkg/src/gempyor/statistics.py
+++ b/flepimop/gempyor_pkg/src/gempyor/statistics.py
@@ -10,8 +10,8 @@ __all__ = ["Statistic"]
 
 import confuse
 import numpy as np
-from scipy.special import gammaln
 import scipy.stats
+from scipy.special import gammaln
 import xarray as xr
 
 

--- a/flepimop/gempyor_pkg/src/gempyor/steps_rk4.py
+++ b/flepimop/gempyor_pkg/src/gempyor/steps_rk4.py
@@ -1,7 +1,9 @@
 import logging
 import numpy as np
+import scipy
+import tqdm
 from numba import jit
-import tqdm, scipy
+
 from .utils import Timer
 
 (

--- a/flepimop/gempyor_pkg/src/gempyor/steps_source.py
+++ b/flepimop/gempyor_pkg/src/gempyor/steps_source.py
@@ -1,7 +1,7 @@
-from numba.pycc import CC
 import numpy as np
 import numba as nb
 from numba import types
+from numba.pycc import CC
 
 cc = CC("steps")
 cc.verbose = True

--- a/flepimop/gempyor_pkg/src/gempyor/testing.py
+++ b/flepimop/gempyor_pkg/src/gempyor/testing.py
@@ -15,12 +15,12 @@ __all__ = [
     "sample_fits_distribution",
 ]
 
-from collections.abc import Generator
-import functools
 import os
-from tempfile import TemporaryDirectory
-from typing import Any, Literal
+import functools
 from pathlib import Path
+from tempfile import TemporaryDirectory
+from collections.abc import Generator
+from typing import Any, Literal
 
 import confuse
 import numpy as np

--- a/flepimop/gempyor_pkg/src/gempyor/utils.py
+++ b/flepimop/gempyor_pkg/src/gempyor/utils.py
@@ -1,13 +1,13 @@
-from collections.abc import Iterable
 import datetime
 import functools
 import logging
 import numbers
 import os
-from pathlib import Path
 import shutil
 import subprocess
 import time
+from pathlib import Path
+from collections.abc import Iterable
 from typing import Any, Callable, Literal
 
 import confuse


### PR DESCRIPTION
### Describe your changes.

This pull request just re-orders import statements in all of the Python files within `gempyor` to make them PEP8 compliant. Mostly it was just grouping and alphabetizing issues. 


### Does this pull request make any user interface changes? If so please describe.

The user interface changes are...

No user interface changes. If you have to add import statements to any files, though, best to check [PEP8 ](https://peps.python.org/pep-0008/#imports)to ensure you add them in the right spot. 


### What does your pull request address? Tag relevant issues.

No GH issue spurred this PR, @TimothyWillard just suggested that it would be best to move towards this.

