### PR TITLE
Only require `seeding_file_type` for 'FolderDraw'

### DIFF
--- a/flepimop/gempyor_pkg/src/gempyor/model_info.py
+++ b/flepimop/gempyor_pkg/src/gempyor/model_info.py
@@ -478,12 +478,15 @@ class ModelInfo:
             ti=self.ti,
             tf=self.tf,
             input_filename=(
-                None
-                if self.seeding_config is None
-                else self.get_input_filename(
+                self.get_input_filename(
                     ftype=self.seeding_config["seeding_file_type"].get(),
                     sim_id=sim_id,
                     extension_override="csv",
                 )
+                if (
+                    self.seeding_config is not None
+                    and self.seeding_config["seeding_file_type"].exists()
+                )
+                else None
             ),
         )

--- a/flepimop/gempyor_pkg/tests/seir/test_seeding.py
+++ b/flepimop/gempyor_pkg/tests/seir/test_seeding.py
@@ -1,4 +1,7 @@
 import os
+
+import pytest
+
 from gempyor import seeding, model_info
 from gempyor.utils import config
 
@@ -52,3 +55,33 @@ class TestSeeding:
             ),
         )
         print(seeding_result)
+
+    def test_seeding_only_requires_seeding_file_type_for_folder_draw(self):
+        for seeding_conf in (
+            {"method": "FolderDraw", "seeding_file_type": "seed"},
+            {"method": "NoSeeding"},
+        ):
+            config.clear()
+            config.read(user=False)
+            config.set_file(f"{DATA_DIR}/config.yml")
+            config["seeding"].set(seeding_conf)
+
+            if seeding_conf["method"] == "FolderDraw":
+                with pytest.raises(FileNotFoundError):
+                    s = model_info.ModelInfo(
+                        config=config,
+                        setup_name="test_seeding",
+                        nslots=1,
+                        seir_modifiers_scenario=None,
+                        outcome_modifiers_scenario=None,
+                        write_csv=False,
+                    ).get_seeding_data(0)
+            else:
+                s = model_info.ModelInfo(
+                    config=config,
+                    setup_name="test_seeding",
+                    nslots=1,
+                    seir_modifiers_scenario=None,
+                    outcome_modifiers_scenario=None,
+                    write_csv=False,
+                ).get_seeding_data(0)


### PR DESCRIPTION
### Describe your changes.

This pull request addresses a bug introduced in GH-422 where the `seeding_file_type` key is required under the `seeding` section, even though it is only meant for when `method='FolderDraw'`. Unfortunately, the unit testing for this bug fix is a big lacking, it is still challenging to directly test the `Seeding` class.

### Does this pull request make any user interface changes? If so please describe.

This PR restores the previously documented behavior here: https://iddynamics.gitbook.io/flepimop/gempyor/model-implementation/specifying-seeding#specifying-model-seeding

### What does your pull request address? Tag relevant issues.

This pull request addresses GH-422.
