### PR TITLE
HPC Init Conda Display

### DIFF
--- a/batch/hpc_init
+++ b/batch/hpc_init
@@ -94,11 +94,16 @@ if [ ! -d $PROJECT_PATH ]; then
     echo "> The project path provided, $PROJECT_PATH, is not a directory. Please ensure this is correct."
 fi
 
-echo -n "Please set a config path (relative to '$PROJECT_PATH'): "
+echo -n "Please set a config path (relative to '$PROJECT_PATH' or press enter to skip): "
 read CONFIG_PATH
-export CONFIG_PATH="$PROJECT_PATH/$CONFIG_PATH"
-if [ ! -f $CONFIG_PATH ]; then
-    echo "> The config path provided, $CONFIG_PATH, is not a file. Please ensure this is correct."
+if [ -z "$CONFIG_PATH" ]; then
+    unset CONFIG_PATH
+    echo "Skipping config path."
+else
+    export CONFIG_PATH="$PROJECT_PATH/$CONFIG_PATH"
+    if [ ! -f $CONFIG_PATH ]; then
+        echo "> The config path provided, $CONFIG_PATH, is not a file. Please ensure this is correct."
+    fi
 fi
 
 echo -n "Please set a validation date (today is $TODAY): "

--- a/batch/hpc_init
+++ b/batch/hpc_init
@@ -149,4 +149,6 @@ EOM
 set +e
 
 # Launch subshell with modified environment
+echo ""
+echo "> Launching subshell with modified environment. To exit, type 'exit'. Subshell may not display conda environment correctly, run 'which python' to verify."
 eval "$SHELL -l"


### PR DESCRIPTION
### Describe your changes.

This pull request:

1. Makes setting the `$CONFIG_PATH` env var optional, and
2. Adds a warning to the user about the conda prompt not displaying correctly in subshell.


### Does this pull request make any user interface changes? If so please describe.

The user interface changes are described above.


### What does your pull request address? Tag relevant issues.

This pull request follows up on GH-419.
