### PR TITLE
Add Clarifications To Before Any Run/Quick Start Guide

### DIFF
--- a/documentation/gitbook/how-to-run/before-any-run.md
+++ b/documentation/gitbook/how-to-run/before-any-run.md
@@ -1,7 +1,7 @@
 ---
 description: >-
-  Instructions on how to begin engaging with flepiMoP both remotely and locally.
-  Provide users with a script that will locally install flepiMoP and all packages/dependencies.
+  Instructions on how to begin engaging with flepiMoP locally by covering GitHub setup,
+  conda installation, and finally installation of flepiMoP itself.
 ---
 
 # Before any run
@@ -37,30 +37,27 @@ Installation of `conda` may take a few minutes.
 
 ## ⬇️ Install flepiMoP packages and dependencies
 
-Navigate to the `flepiMoP` directory and run the following command:
+{% hint style="warning" %}
+This installation script is currently only designed for Linux/MacOS operating systems or linux shells for windows. If you need windows native installation please reach out for assistance.
+{% endhint %}
 
-**Note: This installation script is currently only designed for Mac/Linux operating systems. Windows installation script coming soon.**
+To install `flepiMoP` locally navigate to the `flepiMoP` directory and run the following command:
+
 ```bash
 ./build/local_install_or_update
 ```
-Successfully running this script will do the following:
-1. Determine `$FLEPI_PATH` and `$FLEPI_CONDA` environment variables
-2. Activate your conda environment
-3. Install `gempyor` and related Python dependencies
-4. Install necessary R packages and dependencies
 
-{% hint style="success" %}
-Now you area ready to run the code using your desired method (see below)!
-{% endhint %}
-{% hint style="warning" %}
-If you have any trouble or questions while trying to run `flepimop`, please report them on the [GitHub Q\&A](https://github.com/HopkinsIDD/flepiMoP/discussions/categories/q-a).
-{% endhint %}
+This script will do the following:
+
+1. Determine `$FLEPI_PATH` and `$FLEPI_CONDA` environment variables,
+2. Create and activate a conda environment to install `flepiMoP` into,
+3. Install `gempyor` and related Python dependencies to the conda environment from (2), and
+4. Install necessary R packages and dependencies to the conda environment from (2).
+
+Please inspect the output to ensure that the installation has gone smoothly. If you encounter any issues please report them in a [GitHub issue](https://github.com/HopkinsIDD/flepiMoP/issues). After this step you should be clear to move on to the [Quick Start Guide](./quick-start-guide.md) to activate your installation and do some test runs.
 
 ## 🤔 Deciding how to run
 
 The code is written in a combination of [R](https://www.r-project.org/) and [Python](https://www.python.org/). The Python part of the model is a package called [_gempyor_](../gempyor/model-description.md), and includes all the code to simulate the epidemic model and the observational model and apply time-dependent interventions. The R component conducts the (optional) parameter inference, and all the (optional) provided pre and post processing scripts are also written in R. Most uses of the code require interacting with components written in both languages, and thus making sure that both are installed along with a set of required packages. However, Python alone can be used to do forward simulations of the model using `gempyor`.
 
 Because of the need for multiple software packages and dependencies, we describe different ways you can run the model, depending on the requirements of your model setup. See [Quick Start Guide](quick-start-guide.md) for a quick introduction to using `gempyor` and `flepiMoP`. We also provide some more [advanced](advanced-run-guides/) ways to run our model, particularly for doing more complex model inference tasks.
-
-
-

--- a/documentation/gitbook/how-to-run/quick-start-guide.md
+++ b/documentation/gitbook/how-to-run/quick-start-guide.md
@@ -1,27 +1,49 @@
 ---
 description: >-
-  Instructions to get started with using gempyor and flepiMoP.
-  Executing a simple run with provided example configs.
+  Instructions to get started with using gempyor and flepiMoP, directly following the 
+  steps described in "Before Any Run", by activating your install and running some 
+  sample commands.
 ---
 
 # Quick Start Guide
 
-## 🧱 Set up
+## 🧱 Set Up
 
-Before completing this **Quick Start Guide**, make sureyou have followed all the steps in the [Before any run](before-any-run.md) section to ensure you have access to the correct files needed to run your model with flepiMoP.
+Before completing this **Quick Start Guide**, make sure you have followed all the steps in the [Before any run](before-any-run.md) section to ensure you have access to the correct files needed to run your model with flepiMoP.
 
-### Define environment variables (optional)
+## Activating The Conda Environment
 
-Since you'll be navigating frequently between the folder that contains your project code and the folder that contains the core flepiMoP model code, it's helpful to define shortcuts for these file paths. You can do this by creating environmental variables that you can then quickly call instead of writing out the whole file path.
+First step in using `flepiMoP` is activating the conda environment that it has been installed in:
+
+```bash
+conda activate flepimop-env
+```
+
+Assuming that you installed `flepiMoP` to the default conda environment name, but if you choose to install elsewhere please adjust the above command accordingly.
+
+### Define Environment Variables (Optional)
+
+{% hint style="info" %}
+If you choose not to define environment variables, remember to use the full or relative path names for navigating to the right directories and provide appropriate flepi/project path arguments in future steps.
+{% endhint %}
+
+`flepiMoP` frequently uses two environment variables to refer to specific directories both as a default for CLI arguments and throughout the documentation:
+
+1. `FLEPI_PATH`: Refers to the directory where `flepiMoP` is installed to, and
+2. `PROJECT_PATH`: Refers to the directory where `flepiMoP` is being ran from.
+
+Furthermore, you'll likely be navigating between these directories frequently in production usage so having these environment variables set can save some typing.
 
 For example, if you're on a **Mac** or Linux/Unix based operating system and storing the `flepiMoP` code in a directory called `Github`, you define the FLEPI\_PATH and PROJECT\_PATH environmental variables to be your directory locations as follows:
 
+On Linux/MacOS or in linux shells on windows setting an environment variable can be done by:
+
 ```bash
-export FLEPI_PATH=/Users/YourName/Github/flepiMoP
-export PROJECT_PATH=/Users/YourName/Github/flepiMoP/examples/tutorials
+export FLEPI_PATH=/your/path/to/flepiMoP
+export PROJECT_PATH=/your/path/to/flepiMoP/examples/tutorials
 ```
 
-or, if you have already navigated to your flepiMoP directory
+Where `/your/path/to` is the directory containing `flepiMoP`. If you have already navigated to your flepiMoP directory you can just do:
 
 ```bash
 export FLEPI_PATH=$(pwd)
@@ -30,23 +52,21 @@ export PROJECT_PATH=$(pwd)/examples/tutorials
 
 You can check that the variables have been set by either typing `env` to see all defined environmental variables, or typing `echo $FLEPI_PATH` to see the value of `FLEPI_PATH`.
 
-If you're on a **Windows** machine:
+However, if you're on Windows:
 
-<pre class="language-bash"><code class="lang-bash"><strong>set FLEPI_PATH=C:\Users\YourName\Github\flepiMoP
-</strong>set PROJECT_PATH=C:\Users\YourName\Github\flepiMoP\examples\tutorials
-</code></pre>
+```bash
+set FLEPI_PATH=C:\your\path\to\flepiMoP
+set PROJECT_PATH=C:\your\path\to\flepiMoP\examples\tutorials
+```
 
-or, if you have already navigated to your flepiMoP directory
+Where `/your/path/to` is the directory containing `flepiMoP`. If you have already navigated to your flepiMoP directory you can just do:
 
-<pre class="language-bash"><code class="lang-bash"><strong>set FLEPI_PATH=%CD%
-</strong>set PROJECT_PATH=%CD%\examples\tutorials
-</code></pre>
+```bash
+set FLEPI_PATH=%CD%
+set PROJECT_PATH=%CD%\examples\tutorials
+```
 
 You can check that the variables have been set by either typing `set` to see all defined environmental variables, or typing `echo $FLEPI_PATH$` to see the value of `FLEPI_PATH`.
-
-{% hint style="info" %}
-If you choose not to define environment variables, remember to use the full or relative path names for navigating to the right files or folders in future steps.
-{% endhint %}
 
 ## 🚀 Run the code
 


### PR DESCRIPTION
### Describe your changes.

Added some minor clarifications to the "Before Any Run" and "Quick Start Guide" pages to:
* Clarify differences between installation and setup,
* Add a missing `conda activate ...` step, and
* Elaborate on env vars in quick start.


### Does this pull request make any user interface changes? If so please describe.

Those are reflected in updates to the documentation in "Before Any Run" and "Quick Start Guide".
