### PR TITLE
Fix Lint CI Upgrade `black` From 24 To 25

### DIFF
--- a/flepimop/gempyor_pkg/src/gempyor/calibrate.py
+++ b/flepimop/gempyor_pkg/src/gempyor/calibrate.py
@@ -1,7 +1,7 @@
 """
-Facilitates the calibration of the model using the `emcee` MCMC sampler. 
+Facilitates the calibration of the model using the `emcee` MCMC sampler.
 
-Provides CLI options for users to specify simulation parameters. 
+Provides CLI options for users to specify simulation parameters.
 
 Functions:
     calibrate: Reads a configuration file for simulation settings.

--- a/flepimop/gempyor_pkg/src/gempyor/compartments.py
+++ b/flepimop/gempyor_pkg/src/gempyor/compartments.py
@@ -1,17 +1,17 @@
 """
-Defines class, methods, and functions necessary to establising compartments in the model. 
+Defines class, methods, and functions necessary to establising compartments in the model.
 
 Classes:
-    Compartments: An object to handle compartment data for the model. 
+    Compartments: An object to handle compartment data for the model.
 
 Functions:
     get_list_dimension: Returns length of object passed (if a list); otherwise returns 1.
     list_access_element_safe: Attempts to access something from the given object at specified index.
     list_access_element: Attempts to access soemthing from the given object at specified index.
-    list_recursive_convert_to_string: Convert item(s) in object to str(s). 
-    compartments: A container for subcommands related to the compartmental model. 
-    plot: Generate a plot representing transition between compartments. 
-    export: Export compartment data to a CSV file. 
+    list_recursive_convert_to_string: Convert item(s) in object to str(s).
+    compartments: A container for subcommands related to the compartmental model.
+    plot: Generate a plot representing transition between compartments.
+    export: Export compartment data to a CSV file.
 """
 
 import logging

--- a/flepimop/gempyor_pkg/src/gempyor/inference.py
+++ b/flepimop/gempyor_pkg/src/gempyor/inference.py
@@ -10,21 +10,21 @@
 
 """
 Classes:
-    GempyorInference: 
+    GempyorInference:
         Encapsulates the process of simulation. Provides functionality for parameter
         inference, SEIR model execution, outcome computation, and inference optimization.
 
 Functions:
-    simulation_atomic: 
+    simulation_atomic:
         Runs a SEIR simulation (generates and reduces parameters, executes SEIR
         processes, computes outcomes, handles NPIs and seeding data).
     get_static_arguments: Get the static arguments for the log likelihood function.
     autodetect_senarios: Auto-detect the scenarios provided in config.
-    paramred_parallel: 
-        Initializes a `GempyorInference` object with a configuration file, 
+    paramred_parallel:
+        Initializes a `GempyorInference` object with a configuration file,
         reads specified NPI file, and computes reduced SEIR model specifications
         based on this info. Returns the reduced parameters.
-    paramred_parallel_config: 
+    paramred_parallel_config:
         Initializes a `GempyorInference` object with a configuration file,
         retreives SEIR model specifications and NPIs, and computes reduced
         parameters based on this info. Returns the reduced parameters.

--- a/flepimop/gempyor_pkg/src/gempyor/info.py
+++ b/flepimop/gempyor_pkg/src/gempyor/info.py
@@ -1,13 +1,13 @@
 """
 Retrieving static information from developer managed yaml files.
 
-Currently, it includes utilities for handling cluster-specific information, but it can 
+Currently, it includes utilities for handling cluster-specific information, but it can
 be extended to other categories as needed.
 
 Classes:
     Module: Represents a software module with a name and optional version.
     PathExport: Represents a path export with a path, prepend flag, and error handling.
-    Cluster: Represents a cluster with a name, list of modules, and list of path 
+    Cluster: Represents a cluster with a name, list of modules, and list of path
         exports.
 
 Functions:
@@ -15,17 +15,17 @@ Functions:
 
 Notes:
     By default the order for search paths is:
-    
+
     1) The current working directory, then
     2) The directory specified by the `$FLEPI_INFO_PATH` environment variable if set,
        and finally
     3) The directory specified by the `$FLEPI_PATH` environment variable if set.
-    
+
     The functions in this module will search for an `info/` directory under the search
     paths with a structure of `info/<category>/<name>.yml` where `<category>` is the
     category of the information and `<name>` is the name of the information. The first
     yaml file found will be used to populate the model.
-    
+
     The default search paths can be overridden by passing a list of paths to the
     function being used via the `search_paths` argument.
 

--- a/flepimop/gempyor_pkg/src/gempyor/logging.py
+++ b/flepimop/gempyor_pkg/src/gempyor/logging.py
@@ -1,9 +1,9 @@
 """
 Logging utilities for consistent script output.
 
-This module provides functionality for creating consistent outputs from CLI tools 
+This module provides functionality for creating consistent outputs from CLI tools
 provided by this package. Currently exported are:
-- `ClickHandler`: Custom logging handler specifically designed for CLI output using 
+- `ClickHandler`: Custom logging handler specifically designed for CLI output using
     click.
 - `get_script_logger`: Factory for creating a logger instance with a consistent style
     across CLI tools.

--- a/flepimop/gempyor_pkg/src/gempyor/model_info.py
+++ b/flepimop/gempyor_pkg/src/gempyor/model_info.py
@@ -1,11 +1,11 @@
 """
 Abstractions for interacting with models as a monolithic object.
 
-Defines the `ModelInfo` class (and associated methods), used for setting up and 
+Defines the `ModelInfo` class (and associated methods), used for setting up and
 managing the configuration of a simulation. The primary focuses of a `ModelInfo` object
-are parsing and validating config details (including time frames, subpop info, 
-model parameters, outcomes) and file handling for input and output data. 
-This submodule is intended to serve as a foundational part of flepiMoP's 
+are parsing and validating config details (including time frames, subpop info,
+model parameters, outcomes) and file handling for input and output data.
+This submodule is intended to serve as a foundational part of flepiMoP's
 infrastructure for conducting simulations and storing results.
 
 Classes:

--- a/flepimop/gempyor_pkg/src/gempyor/parameters.py
+++ b/flepimop/gempyor_pkg/src/gempyor/parameters.py
@@ -2,7 +2,7 @@
 Provides abstractions for interacting with the parameters configurations.
 
 Classes:
-    Parameters: 
+    Parameters:
         Encapsulates logic for loading, parsing, and summarizing parameter configurations.
 """
 

--- a/flepimop/gempyor_pkg/tests/parameters/test_parameters_class.py
+++ b/flepimop/gempyor_pkg/tests/parameters/test_parameters_class.py
@@ -192,7 +192,7 @@ def insufficient_dates_parameter_factory(tmp_path: pathlib.Path) -> MockParamete
 
 
 class TestParameters:
-    @pytest.mark.parametrize("factory", [(nonunique_invalid_parameter_factory)])
+    @pytest.mark.parametrize("factory", [nonunique_invalid_parameter_factory])
     def test_nonunique_parameter_names_value_error(
         self,
         tmp_path: pathlib.Path,
@@ -208,7 +208,7 @@ class TestParameters:
         ):
             mock_inputs.create_parameters_instance()
 
-    @pytest.mark.parametrize("factory", [(insufficient_columns_parameter_factory)])
+    @pytest.mark.parametrize("factory", [insufficient_columns_parameter_factory])
     def test_timeseries_parameter_has_insufficient_columns_value_error(
         self,
         tmp_path: pathlib.Path,
@@ -244,7 +244,7 @@ class TestParameters:
         ):
             mock_inputs.create_parameters_instance()
 
-    @pytest.mark.parametrize("factory", [(insufficient_dates_parameter_factory)])
+    @pytest.mark.parametrize("factory", [insufficient_dates_parameter_factory])
     def test_timeseries_parameter_has_insufficient_dates_value_error(
         self,
         tmp_path: pathlib.Path,

--- a/flepimop/gempyor_pkg/tests/statistics/test_statistic_class.py
+++ b/flepimop/gempyor_pkg/tests/statistics/test_statistic_class.py
@@ -313,7 +313,7 @@ all_valid_factories = [
 
 
 class TestStatistic:
-    @pytest.mark.parametrize("factory", [(invalid_regularization_factory)])
+    @pytest.mark.parametrize("factory", [invalid_regularization_factory])
     def test_unsupported_regularizations_value_error(
         self, factory: Callable[[], MockStatisticInput]
     ) -> None:
@@ -618,7 +618,7 @@ class TestStatistic:
                 ),
             )
 
-    @pytest.mark.parametrize("factory", [(invalid_misshaped_data_factory)])
+    @pytest.mark.parametrize("factory", [invalid_misshaped_data_factory])
     def test_compute_logloss_data_misshape_value_error(
         self, factory: Callable[[], MockStatisticInput]
     ) -> None:


### PR DESCRIPTION
### Describe your changes.

This pull request reformats the `dev` branch. Update to `black` brought changes to whitespace formatting that broke CI. See:

- Last success from 2025-02-25 with version 24.10.0: https://github.com/HopkinsIDD/flepiMoP/actions/runs/13528206416
- Recent failure from 2025-03-11 with version 25.1.0: https://github.com/HopkinsIDD/flepiMoP/actions/runs/13793287087


### Does this pull request make any user interface changes? If so please describe.

The user interface changes are none and no documentation required.


### What does your pull request address? Tag relevant issues.

This pull request has no corresponding issue.