### PR TITLE
Envvar documentation

### DIFF
--- a/batch/inference_job_launcher.py
+++ b/batch/inference_job_launcher.py
@@ -260,7 +260,7 @@ def user_confirmation(question="Continue?", default=False):
     "continuation_location",
     type=str,
     default=None,
-    envvar="CONTINUATION_LOCATION",
+    envvar="FLEPI_CONTINUATION_LOCATION",
     help="The location (folder or an S3 bucket) from which to pull the /init/ files (if not set, uses the resume location seir files)",
 )
 @click.option(
@@ -269,6 +269,7 @@ def user_confirmation(question="Continue?", default=False):
     "continuation_run_id",
     type=str,
     default=None,
+    envvar="FLEPI_CONTINUATION_RUN_ID",
     help="The run_id of the run we are continuing from",
 )
 def launch_batch(

--- a/documentation/gitbook/how-to-run/environmental-variables.md
+++ b/documentation/gitbook/how-to-run/environmental-variables.md
@@ -1,0 +1,463 @@
+--- 
+description: >-
+    A library of environmental variables in the flepiMoP codebase.
+    These variables may be updated or deprecated as the project evolves.
+---
+
+# Environmental Variables 🌍
+
+Below you will find a list of environmental variables (envvars) defined throughout the flepiMoP codebase. Often, these variables are set in reponse to command-line argument input. 
+
+<table>
+    <thead>
+        <tr>
+            <th width="135">Envvar.</th>
+            <th width="100">Argument</th>
+            <th width="300">Description</th>
+            <th width="115">Default</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td><code>BATCH_SYSTEM</code></td>
+            <td>N/A</td>
+            <td>System you are running on (e.g., aws, SLURM, local).</td>
+            <td>N/A</td>
+        </tr>
+        <tr>
+            <td><code>CENSUS_API_KEY</code></td>
+            <td>N/A</td>
+            <td>A unique key to the API for census data.</td>
+            <td>N/A</td>
+        </tr>
+        <tr>
+            <td><code>CONDA_PREFIX</code></td>
+            <td>N/A</td>
+            <td>Holds the path to the active conda environment. Used to determine the installation path for CLI installation.</td>
+            <td>N/A</td>
+        </tr>
+        <tr>
+            <td><code>CONFIG_PATH</code></td>
+            <td><code>-c</code>, <code>--config</code></td>
+            <td>Path to a configuration file.</td>
+            <td>--</td>
+        </tr>
+        <tr>
+            <td><code>CONTINUATION_LOCATION</code></td>
+            <td><code>--continuation-location</code></td>
+            <td>The location (folder or an S3 bucket) from which to pull the init files (if not set, uses the resume location seir files)</td>
+            <td>--</td>
+        </tr>
+        <tr>
+            <td><code>DELPHI_API_KEY</code></td>
+            <td><code>-d</code>, <code>--delhpi_api_key</code></td>
+            <td>Your personalized key for the Delphi Epidata API. Alternatively, this key can go in the config inference section as <code>gt_api_key</code>.</td>
+            <td>--</td>
+        </tr>
+        <tr>
+            <td><code>DIAGNOSTICS</code></td>
+            <td><code>-n</code>, <code>--run-diagnostics</code></td>
+            <td>Flag for whether or not diagnostic tests should be run during execution.</td>
+            <td><code>True</code></td>
+        </tr>
+        <tr>
+            <td><code>DISEASE</code></td>
+            <td><code>-i</code>, <code>--disease</code></td>
+            <td>Which disease is being simulated in the prsent run.</td>
+            <td><code>'flu'</code></td>
+        </tr>
+        <tr>
+            <td><code>DVC_OUTPUTS</code></td>
+            <td>N/A</td>
+            <td>The names of the directories with outputs to save in S3 (separated by a space).</td>
+            <td>N/A</td>
+        </tr>
+        <tr>
+            <td><code>FILENAME</code></td>
+            <td>N/A</td>
+            <td>Filenames for output files, determined dynamically during inference.</td>
+            <td>N/A</td>
+        </tr>
+        <tr>
+            <td><code>FIRST_SIM_INDEX</code></td>
+            <td><code>-i</code>, <code>--first_sim_index</code></td>
+            <td>The index of the first simulation.</td>
+            <td><code>1</code></td>
+        </tr>
+        <tr>
+            <td><code>FLEPI_BLOCK_INDEX</code></td>
+            <td><code>-b</code>, <code>--this_block</code></td>
+            <td>Index of current block.</td>
+            <td><code>1</code></td>
+        </tr>
+        <tr>
+            <td><code>FLEPI_CONDA</code></td>
+            <td>N/A</td>
+            <td>Pathway to the conda environment (used only during initial user install).</td>
+            <td>N/A></td>
+        </tr>
+        <tr>
+            <td><code>FLEPI_CONTINUATION</code></td>
+            <td><code>--continuation</code>/<code>--no-continuation</code></td>
+            <td>Flag for whether or not to use the resumed run seir files (or provided initial files bucket) as initial conditions for the next run.</td>
+            <td><code>False</code></td>
+        </tr>
+        <tr>
+            <td><code>FLEPI_CONTINUATION_FTYPE</code></td>
+            <td>N/A</td>
+            <td>If running a continuation, the file type of the initial condition files.</td>
+            <td>N/A</td>
+        </tr>
+        <tr>
+            <td><code>FLEPI_INFO_PATH</code></td>
+            <td><code></code></td>
+            <td>See <code>info.py</code></td>
+            <td><code></code></td>
+        </tr>
+        <tr>
+            <td><code>FLEPI_ITERATIONS_PER_SLOT</code></td>
+            <td><code>-k</code>, <code>--iterations_per_slot</code></td>
+            <td>Number of iterations to run per slot.</td>
+            <td>--</td>
+        </tr>
+        <tr>
+            <td><code>FLEPI_MAX_STACK_SIZE</code></td>
+            <td><code>--stacked-max</code></td>
+            <td>Maximum number of iterventions to allow in a stacked intervention.</td>
+            <td><code>5000</code></td>
+        </tr>
+        <tr>
+            <td><code>FLEPI_MEM_PROFILE</code></td>
+            <td><code>-M</code>, <code>--memory_profiling</code></td>
+            <td>Flag for whether or not memory profile should be run during iterations.</td>
+            <td><code>False</code></td>
+        </tr>
+        <tr>
+            <td><code>FLEPI_MEM_PROFILE_ITERS</code></td>
+            <td><code>-P</code>, <code>--memory_profiling_iters</code></td>
+            <td>If doing memory profiling, after every X iterations, run the profiling.</td>
+            <td><code>100</code></td>
+        </tr>
+        <tr>
+            <td><code>FLEPI_NJOBS</code></td>
+            <td><code>-j</code>, <code>--jobs</code></td>
+            <td>Number of parallel processors used to run the simulation. If there are more slots than jobs, slots will be divided up between processors and run in series on each.</td>
+            <td>Number of cores detected as available at computing cluster.</td>
+        </tr>
+        <tr>
+            <td><code>FLEPI_NPI_SCENARIOS</code></td>
+            <td><code></code></td>
+            <td></td>
+            <td><code></code></td>
+        </tr>
+        <tr>
+            <td><code>FLEPI_NUM_SLOTS</code></td>
+            <td><code>-n</code, <code>--slots</code></td>
+            <td>Number of independent simulations of the model to be run.</td>
+            <td>--</td>
+        </tr>
+        <tr>
+            <td><code>FLEPI_OUTCOME_SCENARIOS</code></td>
+            <td><code>-d</code>, <code>--outcome_modifiers_scenarios</code></td>
+            <td>Name of the outcome scenario to run.</td>
+            <td><code>'all'</code></td>
+        </tr>
+        <tr>
+            <td><code>FLEPI_PATH</code></td>
+            <td><code>-p</code>, <code>--flepi_path</code></td>
+            <td>Path to the flepiMoP directory.</td>
+            <td><code>'flepiMoP'</code></td>
+        </tr>
+        <tr>
+            <td><code>FLEPI_PREFIX</code></td>
+            <td><code>--in-prefix</code></td>
+            <td>Unique identifier for the run.</td>
+            <td>--</td>
+        </tr>
+        <tr>
+            <td><code>FLEPI_RESET_CHIMERICS</code></td>
+            <td><code>-L</code>, <code>--reset_chimeric_on_accept</code></td>
+            <td>Flag for whether or not chimeric parameters should be reset to global parameters whena  global acceptance occurs.</td>
+            <td><code>True</code></td>
+        </tr>
+        <tr>
+            <td><code>FLEPI_RESUME</code></td>
+            <td><code>--resume</code>/<code>--no-resume</code></td>
+            <td>Flag for whether or not to resume the current calibration.</td>
+            <td><code>False</code></td>
+        </tr>
+        <tr>
+            <td><code>FLEPI_RUN_INDEX</code></td>
+            <td><code>-u</code>, <code>--run_id</code></td>
+            <td>Unique ID given to the model run. If the same config is run multiple times, you can avoid the output being overwritten by using unique model run IDs.</td>
+            <td>Auto-assigned run ID</td>
+        </tr>
+        <tr>
+            <td><code>FLEPI_SEIR_SCENARIOS</code></td>
+            <td><code>-s</code>, <code>--seir_modifier_scenarios</code></td>
+            <td>Names of the intervention scenarios to run.</td>
+            <td><code>'all'</code></td>
+        </tr>
+        <tr>
+            <td><code>FLEPI_SLOT_INDEX</code></td>
+            <td><code>-i</code>, <code>--this_slot</code></td>
+            <td>Index for current slots.</td>
+            <td><code>1</code></td>
+        </tr>
+        <tr>
+            <td><code>FLEPI_STOCHASTIC_RUN</code></td>
+            <td><code>-t</code>, <code>--stoch_traj_flag</code></td>
+            <td>Whether or not the model should be run stochastically or non-stochastically (deterministic numerical integration of equations using the RK4 algorithm)</td>
+            <td><code>False</code></td>
+        </tr>
+        <tr>
+            <td><code>FS_RESULTS_PATH</code></td>
+            <td><code>-R</code>, <code>--results-path</code></td>
+            <td>A path to the model results.</td>
+            <td>--</td>
+        </tr>
+        <tr>
+            <td><code>FULL_FIT</code></td>
+            <td><code>-F</code>, <code>--full-fit</code></td>
+            <td>Whether or not to process the full fit.</td>
+            <td><code>False</code></td>
+        </tr>
+        <tr>
+            <td><code>GT_DATA_SOURCE</code></td>
+            <td><code>-s</code>, <code>--gt_data_source</code></td>
+            <td>Sources of groundtruth data.</td>
+            <td><code>'csse_case, fluview_death, hhs_hosp'</code></td>
+        </tr>
+        <tr>
+            <td><code>GT_END_DATE</code></td>
+            <td><code>--ground_truth_end</code></td>
+            <td>Last date to include ground truth for.</td>
+            <td>--</td>
+        </tr>
+        <tr>
+            <td><code>GT_START_DATE</code></td>
+            <td><code>--ground_truth_start</code></td>
+            <td>First date to include ground truth for.</td>
+            <td>--</td>
+        </tr>
+        <tr>
+            <td><code>IMM_ESC_PROP</code></td>
+            <td><code>--imm_esc_prop</code></td>
+            <td>Annual percent of immune escape.</td>
+            <td><code>0.35</code></td>
+        </tr>
+        <tr>
+            <td><code>INCL_AGGR_LIKELIHOOD</code></td>
+            <td><code>-a</code>, <code>--incl_aggr_likelihood</code></td>
+            <td>Whether or not the likelihood should be calculated with aggregate estimates.</td>
+            <td><code>False</code></td>
+        </tr>
+        <tr>
+            <td><code>IN_FILENAME</code></td>
+            <td>N/A</td>
+            <td>Name of input files.</td>
+            <td>N/A</td>
+        </tr>
+        <tr>
+            <td><code>INIT_FILENAME</code></td>
+            <td><code>--init_file_name</code></td>
+            <td>Initial file global intermediate name.</td>
+            <td>--</td>
+        </tr>
+        <tr>
+            <td><code>INTERACTIVE_RUN</code></td>
+            <td><code>-I</code>, <code>--is-interactive</code></td>
+            <td>Whether or not the current run is interactive.</td>
+            <td><code>False</code></td>
+        </tr>
+        <tr>
+            <td><code>JOB_NAME</code></td>
+            <td><code>--job-name</code></td>
+            <td>Unique job name (intended for use when submitting to SLURM).</td>
+            <td>--</td>
+        </tr>
+        <tr>
+            <td><code>LAST_JOB_OUTPUT</code></td>
+            <td>N/A</td>
+            <td>Path to output of last job.</td>
+            <td>N/A</td>
+        </tr>
+        <tr>
+            <td><code>OLD_FLEPI_RUN_INDEX</code></td>
+            <td>N/A</td>
+            <td>Run ID of old flepiMoP run.</td>
+            <td>N/A</td>
+        </tr>
+        <tr>
+            <td><code>OUT_FILENAME</code></td>
+            <td>N/A</td>
+            <td>Name of output files.</td>
+            <td>N/A</td>
+        </tr>
+        <tr>
+            <td><code>OUT_FILENAME_DIR</code></td>
+            <td>N/A</td>
+            <td>Directory for output files.</td>
+            <td>N/A</td>
+        </tr>
+        <tr>
+            <td><code>OUTPUTS</code></td>
+            <td><code>-o</code>, <code>--select-outputs</code></td>
+            <td>A list of outputs to plot.</td>
+            <td><code>'hosp, hnpi, snpi, llik'</code></td>
+        </tr>
+        <tr>
+            <td><code>PARQUET_TYPES</code></td>
+            <td>N/A</td>
+            <td>Parquet files.</td>
+            <td><code>'seed spar snpi seir hpar hnpi hosp llik init'</code></td>
+        </tr>
+        <tr>
+            <td><code>PATH</code></td>
+            <td>N/A</td>
+            <td>Path relating to AWS installation. Used during SLURM runs.</td>
+            <td>N/A</td>
+        </tr>
+        <tr>
+            <td><code>PROCESS</code></td>
+            <td><code>-r</code>, <code>--run-processing</code></td>
+            <td>Whether or not to process the run.</td>
+            <td><code>False</code></td>
+        </tr>
+        <tr>
+            <td><code>PROJECT_PATH</code></td>
+            <td><code>-d</code>, <code>--data_path</code></td>
+            <td>Path to the folder with configs and model output.</td>
+            <td>--</td>
+        </tr>
+        <tr>
+            <td><code>PULL_GT</code></td>
+            <td><code>-g</code>, <code>--pull-gt</code></td>
+            <td>Whether or not to pull ground truth data.</td>
+            <td><code>False</code></td>
+        </tr>
+        <tr>
+            <td><code>PYTHON_PATH</code></td>
+            <td><code>-y</code>, <code>--python</code></td>
+            <td>Path to Python executable.</td>
+            <td><code>'python3'</code></td>
+        </tr>
+        <tr>
+            <td><code>RESUMED_CONFIG_PATH</code></td>
+            <td><code>--res_config</code></td>
+            <td>Path to previous config file, if using resumes.</td>
+            <td><code>NA</code></td>
+        </tr>
+        <tr>
+            <td><code>RESUME_DISCARD_SEEDING</code></td>
+            <td><code>--resume-discard-seeding</code>, <code>--resume-carry-seeding</code></td>
+            <td>Whether or not to keep seeding in resume runs.</td>
+            <td><code>False</code></td>
+        </tr>
+        <tr>
+            <td><code>RESUME_LOCATION</code></td>
+            <td><code>-r</code>, <code>--restart-from-location</code></td>
+            <td>The location (folder or an S3 bucket) where the previous run is stored.</td>
+            <td>--</td>
+        </tr>
+        <tr>
+            <td><code>RESUME_RUN</code></td>
+            <td><code>-R</code>, <code>--is-resume</code></td>
+            <td>Whether or not this run is a resume.</td>
+            <td><code>False</code></td>
+        </tr>
+        <tr>
+            <td><code>RSCRIPT_PATH</code></td>
+            <td><code>-r</code>, <code>--rpath</code></td>
+            <td>Path to R executable.</td>
+            <td><code>'Rscript'</code></td>
+        </tr>
+        <tr>
+            <td><code>RUN_INTERACTIVE</code></td>
+            <td><code>-I</code>, <code>--is-interactive</code></td>
+            <td>Whether or not the current run is interactive.</td>
+            <td><code>False</code></td>
+        </tr>
+        <tr>
+            <td><code>SAVE_HOSP</code></td>
+            <td><code>-H</code>, <code>--save_hosp</code></td>
+            <td>Whether or not the HOSP output files should be saved for each iteration.</td>
+            <td><code>True</code></td>
+        </tr>
+        <tr>
+            <td><code>SAVE_SEIR</code></td>
+            <td><code>-S</code>, <code>--save_seir</code></td>
+            <td>Whether or not the SEIR output files should be saved for each iteration.</td>
+            <td><code>False</code></td>
+        </tr>
+        <tr>
+            <td><code>SCENARIO</code></td>
+            <td><code></code></td>
+            <td></td>
+            <td><code></code></td>
+        </tr>
+        <tr>
+            <td><code>SEED_VARIANTS</code></td>
+            <td><code>-s</code>, <code>--seed_variants</code></td>
+            <td>Whether or not to add variants/subtypes to outcomes in seeding.</td>
+            <td>--</td>
+        </tr>
+        <tr>
+            <td><code>SIMS_PER_JOB</code></td>
+            <td>N/A</td>
+            <td>Simulations per job.</td>
+            <td>N/A</td>
+        </tr>
+        <tr>
+            <td><code>SLACK_CHANNEL</code></td>
+            <td><code>-s</code>, <code>--slack-channel</code></td>
+            <td>Slack channel, either 'csp-production' or 'debug'; or 'noslack' to disable slack.</td>
+            <td>--</td>
+        </tr>
+        <tr>
+            <td><code>SLACK_TOKEN</code></td>
+            <td><code>-s</code>, <code>--slack-token</code></td>
+            <td>Slack token.</td>
+            <td>--</td>
+        </tr>
+        <tr>
+            <td><code>SUBPOP_LENGTH</code></td>
+            <td><code>-g</code>, <code>--subpop_len</code></td>
+            <td>Number of digits in subpops.</td>
+            <td><code>5</code></td>
+        </tr>
+        <tr>
+            <td><code>S3_MODEL_PROJECT_PATH</code></td>
+            <td>N/A</td>
+            <td>Location in S3 bucket with the code, data, and dvc pipeline.</td>
+            <td>N/A</td>
+        </tr>
+        <tr>
+            <td><code>S3_RESULTS_PATH</code></td>
+            <td>N/A</td>
+            <td>Location in S3 to store results.</td>
+            <td>N/A</td>
+        </tr>
+        <tr>
+            <td><code>S3_UPLOAD</code></td>
+            <td>N/A</td>
+            <td>Whether or not to upload S3 buckets.</td>
+            <td>N/A</td>
+        </tr>
+        <tr>
+            <td><code>VALIDATION_DATE</code></td>
+            <td><code>--validation-end-date</code></td>
+            <td>First date of projection/forecast (first date without ground truth data).</td>
+            <td><code>date.today()</code></td>
+        </tr>
+    </tbody>
+</table>
+
+
+
+
+
+
+
+
+

--- a/documentation/gitbook/how-to-run/environmental-variables.md
+++ b/documentation/gitbook/how-to-run/environmental-variables.md
@@ -91,12 +91,6 @@ Below you will find a list of environmental variables (envvars) defined througho
             <td><code>1</code></td>
         </tr>
         <tr>
-            <td><code>FLEPI_CONDA</code></td>
-            <td>N/A</td>
-            <td>Pathway to the conda environment (used only during initial user install).</td>
-            <td>N/A></td>
-        </tr>
-        <tr>
             <td><code>FLEPI_CONTINUATION</code></td>
             <td><code>--continuation</code>/<code>--no-continuation</code></td>
             <td>Flag for whether or not to use the resumed run seir files (or provided initial files bucket) as initial conditions for the next run.</td>
@@ -106,6 +100,18 @@ Below you will find a list of environmental variables (envvars) defined througho
             <td><code>FLEPI_CONTINUATION_FTYPE</code></td>
             <td>N/A</td>
             <td>If running a continuation, the file type of the initial condition files.</td>
+            <td>N/A</td>
+        </tr>
+        <tr>
+            <td><code>FLEPI_CONTINUATION_LOCATION</code></td>
+            <td><code>--continuation-location</code></td>
+            <td>The location (folder or an S3 bucket) from which to pull the /init/ files (if not set, uses the resume location seir files).</td>
+            <td>N/A</td>
+        </tr>
+        <tr>
+            <td><code>FLEPI_CONTINUATION_RUN_ID</code></td>
+            <td><code>--continuation-run-id</code></td>
+            <td>The ID of run to continue at, if doing a continuation.</td>
             <td>N/A</td>
         </tr>
         <tr>
@@ -143,12 +149,6 @@ Below you will find a list of environmental variables (envvars) defined througho
             <td><code>-j</code>, <code>--jobs</code></td>
             <td>Number of parallel processors used to run the simulation. If there are more slots than jobs, slots will be divided up between processors and run in series on each.</td>
             <td>Number of cores detected as available at computing cluster.</td>
-        </tr>
-        <tr>
-            <td><code>FLEPI_NPI_SCENARIOS</code></td>
-            <td><code></code></td>
-            <td></td>
-            <td><code></code></td>
         </tr>
         <tr>
             <td><code>FLEPI_NUM_SLOTS</code></td>
@@ -389,12 +389,6 @@ Below you will find a list of environmental variables (envvars) defined througho
             <td><code>-S</code>, <code>--save_seir</code></td>
             <td>Whether or not the SEIR output files should be saved for each iteration.</td>
             <td><code>False</code></td>
-        </tr>
-        <tr>
-            <td><code>SCENARIO</code></td>
-            <td><code></code></td>
-            <td></td>
-            <td><code></code></td>
         </tr>
         <tr>
             <td><code>SEED_VARIANTS</code></td>

--- a/documentation/gitbook/how-to-run/environmental-variables.md
+++ b/documentation/gitbook/how-to-run/environmental-variables.md
@@ -6,7 +6,7 @@ description: >-
 
 # Environmental Variables 🌍
 
-Below you will find a list of environmental variables (envvars) defined throughout the flepiMoP codebase. Often, these variables are set in reponse to command-line argument input. 
+Below you will find a list of environmental variables (envvars) defined throughout the flepiMoP codebase. Often, these variables are set in reponse to command-line argument input. Though, some are set by `flepiMoP` without direct user input (these are denoted by a 'Not a CL option' note in the **Argument** column.)
 
 <table>
     <thead>
@@ -15,443 +15,562 @@ Below you will find a list of environmental variables (envvars) defined througho
             <th width="100">Argument</th>
             <th width="300">Description</th>
             <th width="115">Default</th>
+            <th width="150">Valid values</th> 
+            <th width="150">Key file locations (inexhaustive)</th>
         </tr>
     </thead>
     <tbody>
         <tr>
             <td><code>BATCH_SYSTEM</code></td>
-            <td>N/A</td>
+            <td>Not a CL option.</td>
             <td>System you are running on (e.g., aws, SLURM, local).</td>
             <td>N/A</td>
+            <td>e.g., <code>aws</code>, <code>slurm</code></td>
+            <td><code>inference_job_launcher.py</code></td>
         </tr>
         <tr>
             <td><code>CENSUS_API_KEY</code></td>
-            <td>N/A</td>
+            <td>Not a CL option.</td>
             <td>A unique key to the API for census data.</td>
             <td>N/A</td>
-        </tr>
-        <tr>
-            <td><code>CONDA_PREFIX</code></td>
-            <td>N/A</td>
-            <td>Holds the path to the active conda environment. Used to determine the installation path for CLI installation.</td>
-            <td>N/A</td>
+            <td><a href="https://api.census.gov/data/key_signup.html">Get your own API key</a></td>
+            <td><code>slurm_init.sh</code>, <code>build_US_setup.R</code></td>
         </tr>
         <tr>
             <td><code>CONFIG_PATH</code></td>
             <td><code>-c</code>, <code>--config</code></td>
             <td>Path to a configuration file.</td>
             <td>--</td>
-        </tr>
-        <tr>
-            <td><code>CONTINUATION_LOCATION</code></td>
-            <td><code>--continuation-location</code></td>
-            <td>The location (folder or an S3 bucket) from which to pull the init files (if not set, uses the resume location seir files)</td>
-            <td>--</td>
+            <td><code>your/path/to/config_file</code></td>
+            <td><code>build_covid_data.R</code>, <code>build_US_setup.R</code>, <code>build_initial_seeding.R</code>, <code>build_flu_data.R</code>, <code>config.R</code>, <code>preprocessing/</code> files</td>
         </tr>
         <tr>
             <td><code>DELPHI_API_KEY</code></td>
             <td><code>-d</code>, <code>--delhpi_api_key</code></td>
             <td>Your personalized key for the Delphi Epidata API. Alternatively, this key can go in the config inference section as <code>gt_api_key</code>.</td>
             <td>--</td>
+            <td><a href="https://cmu-delphi.github.io/delphi-epidata/api/api_keys.html">Get your own API key</a></td>
+            <td><code>build_covid_data.R</code></td>
         </tr>
         <tr>
             <td><code>DIAGNOSTICS</code></td>
             <td><code>-n</code>, <code>--run-diagnostics</code></td>
             <td>Flag for whether or not diagnostic tests should be run during execution.</td>
-            <td><code>True</code></td>
+            <td><code>TRUE</code></td>
+            <td><code>--run-diagnostics FALSE</code> for <code>FALSE</code>, <code>--run-diagnostics</code> or no mention for <code>TRUE</code></td>
+            <td><code>run_sim_processing_SLURM.R</code></td>
         </tr>
         <tr>
             <td><code>DISEASE</code></td>
             <td><code>-i</code>, <code>--disease</code></td>
             <td>Which disease is being simulated in the prsent run.</td>
-            <td><code>'flu'</code></td>
+            <td><code>flu</code></td>
+            <td>e.g., <code>rsv</code>, <code>covid</code></td>
+            <td><code>run_sim_processing_SLURM.R</code>/td>
         </tr>
         <tr>
             <td><code>DVC_OUTPUTS</code></td>
-            <td>N/A</td>
+            <td>Not a CL option, but defined using <code>--output</code></td>
             <td>The names of the directories with outputs to save in S3 (separated by a space).</td>
-            <td>N/A</td>
+            <td><code>model_output model_parameters importation hospitalization</code></td>
+            <td>e.g., <code>model_output model_parameters importation hospitalization</code></td>
+            <td><code>scenario_job.py</code>, <code>AWS_scenario_runner.sh</code></td>
         </tr>
         <tr>
             <td><code>FILENAME</code></td>
-            <td>N/A</td>
+            <td>Not a CL option.</td>
             <td>Filenames for output files, determined dynamically during inference.</td>
             <td>N/A</td>
+            <td><code>file.parquet</code>, <code>plot.pdf</code></td>
+            <td><code>AWS_postprocess_runner.sh</code>, <code>SLURM_inference_job.run</code>, <code>AWS_inference_runner.sh</code></td>
         </tr>
         <tr>
             <td><code>FIRST_SIM_INDEX</code></td>
             <td><code>-i</code>, <code>--first_sim_index</code></td>
             <td>The index of the first simulation.</td>
             <td><code>1</code></td>
+            <td><code>int</code></td>
+            <td><code>shared_cli.py</code></td>
         </tr>
         <tr>
             <td><code>FLEPI_BLOCK_INDEX</code></td>
             <td><code>-b</code>, <code>--this_block</code></td>
             <td>Index of current block.</td>
             <td><code>1</code></td>
+            <td><code>int</code></td>
+            <td><code>flepimop-inference-main.R</code>, <code>utils.py</code>, <code>AWS_postprocess_runner.sh</code>, <code>AWS_inference_runner.sh</code>, <code>SLURM_inference_job.run</code>, <code>inference_job_launcher.py</code></td>
         </tr>
         <tr>
             <td><code>FLEPI_CONTINUATION</code></td>
             <td><code>--continuation</code>/<code>--no-continuation</code></td>
             <td>Flag for whether or not to use the resumed run seir files (or provided initial files bucket) as initial conditions for the next run.</td>
-            <td><code>False</code></td>
+            <td><code>FALSE</code></td>
+            <td><code>--continuation TRUE</code> for <code>TRUE</code>, <code>--continuation</code> or no mention for <code>FALSE</code></td>
+            <td><code>SLURM_inference_job.run</code>, <code>inference_job_launcher.py</code></td> 
         </tr>
         <tr>
             <td><code>FLEPI_CONTINUATION_FTYPE</code></td>
-            <td>N/A</td>
+            <td>Not a CL option.</td>
             <td>If running a continuation, the file type of the initial condition files.</td>
-            <td>N/A</td>
+            <td><code>config['initial_conditions']['initial_file_type']</code></td>
+            <td>e.g., <code>.csv</code></td>
+            <td><code>SLURM_inference_job.run</code>, <code>inference_job_launcher.py</code></td>
         </tr>
         <tr>
             <td><code>FLEPI_CONTINUATION_LOCATION</code></td>
             <td><code>--continuation-location</code></td>
             <td>The location (folder or an S3 bucket) from which to pull the /init/ files (if not set, uses the resume location seir files).</td>
-            <td>N/A</td>
+            <td>--</td>
+            <td><code>path/to/your/location</code></td>
+            <td><code>SLURM_inference_job.run</code>, <code>inference_job_launcher.py</code></td>
         </tr>
         <tr>
             <td><code>FLEPI_CONTINUATION_RUN_ID</code></td>
             <td><code>--continuation-run-id</code></td>
             <td>The ID of run to continue at, if doing a continuation.</td>
-            <td>N/A</td>
+            <td>--</td>
+            <td><code>int</code></td>
+            <td><code>SLURM_inference_job.run</code>, <code>inference_job_launcher.py</code></td>
         </tr>
         <tr>
             <td><code>FLEPI_INFO_PATH</code></td>
-            <td><code></code></td>
-            <td>See <code>info.py</code></td>
-            <td><code></code></td>
+            <td>Not a CL option.</td>
+            <td><i>pending</i></td>
+            <td><i>pending</i></td>
+            <td><i>pending</i></td>
+            <td><code>info.py</code></td>
         </tr>
         <tr>
             <td><code>FLEPI_ITERATIONS_PER_SLOT</code></td>
             <td><code>-k</code>, <code>--iterations_per_slot</code></td>
             <td>Number of iterations to run per slot.</td>
             <td>--</td>
+            <td><code>int</code></td>
+            <td><code>flepimop-inference-slot.R</code>, <code>flepimop-inference-main.R</code>, <code>SLURM_inference_job.run</code>, <code>inference_job_launcher.py</code></td>
         </tr>
         <tr>
             <td><code>FLEPI_MAX_STACK_SIZE</code></td>
             <td><code>--stacked-max</code></td>
             <td>Maximum number of iterventions to allow in a stacked intervention.</td>
             <td><code>5000</code></td>
+            <td><code>int >=350</code></td>
+            <td><code>StackedModifier.py</code>, <code>inference_job_launcher.py</code></td>
         </tr>
         <tr>
             <td><code>FLEPI_MEM_PROFILE</code></td>
             <td><code>-M</code>, <code>--memory_profiling</code></td>
             <td>Flag for whether or not memory profile should be run during iterations.</td>
-            <td><code>False</code></td>
+            <td><code>FALSE</code></td>
+            <td><code>--memory_profiling TRUE</code> for <code>TRUE</code>, <code>--memory_profiling</code> or no mention for <code>FALSE</code></td>
+            <td><code>flepimop-inference-slot.R</code>, <code>flepimop-inference-main.R</code>, <code>inference_job_launcher.py</code></td>
         </tr>
         <tr>
-            <td><code>FLEPI_MEM_PROFILE_ITERS</code></td>
+            <td><code>FLEPI_MEM_PROF_ITERS</code></td>
             <td><code>-P</code>, <code>--memory_profiling_iters</code></td>
             <td>If doing memory profiling, after every X iterations, run the profiling.</td>
             <td><code>100</code></td>
+            <td><code>int</code></td>
+            <td><code>flepimop-inference-slot.R</code>, <code>flepimop-inference-main.R</code>, <code>inference_job_launcher.py</code></td>
         </tr>
         <tr>
             <td><code>FLEPI_NJOBS</code></td>
             <td><code>-j</code>, <code>--jobs</code></td>
             <td>Number of parallel processors used to run the simulation. If there are more slots than jobs, slots will be divided up between processors and run in series on each.</td>
             <td>Number of cores detected as available at computing cluster.</td>
+            <td><code>int</code></td>
+            <td><code>flepimop-inference-slot.R</code>, <code>flepimop-inference-main.R</code>, <code>calibrate.py</code></td>
         </tr>
         <tr>
             <td><code>FLEPI_NUM_SLOTS</code></td>
             <td><code>-n</code, <code>--slots</code></td>
             <td>Number of independent simulations of the model to be run.</td>
             <td>--</td>
+            <td><code>int >=1</code></td>
+            <td><code>flepimop-inference-slot.R</code>, <code>flepimop-inference-main.R</code>, <code>calibrate.py</code>, <code>inference_job_launcher.py</code></td>
         </tr>
         <tr>
             <td><code>FLEPI_OUTCOME_SCENARIOS</code></td>
             <td><code>-d</code>, <code>--outcome_modifiers_scenarios</code></td>
             <td>Name of the outcome scenario to run.</td>
             <td><code>'all'</code></td>
+            <td><i>pending</i></td>
+            <td><code>flepimop-inference-slot.R</code>, <code>flepimop-inference-main.R</code>, <code>SLURM_inference_job.run</code>, <code>inference_job_launcher.py</code></td>
         </tr>
         <tr>
             <td><code>FLEPI_PATH</code></td>
             <td><code>-p</code>, <code>--flepi_path</code></td>
             <td>Path to the flepiMoP directory.</td>
             <td><code>'flepiMoP'</code></td>
+            <td><code>path/to/flepiMoP</code></td>
+            <td>several <code>postprocessing/</code> files, several <code>batch/</code> files, several <code>preprocessing/</code> files, <code>info.py</code>, <code>utils.py</code>, <code>_cli.py</code></td>
         </tr>
         <tr>
             <td><code>FLEPI_PREFIX</code></td>
             <td><code>--in-prefix</code></td>
-            <td>Unique identifier for the run.</td>
+            <td>Unique name for the run.</td>
             <td>--</td>
+            <td>e.g., <code>project_scenario1_outcomeA</code>, etc.</td>
+            <td><code>SLURM_inference_job.run</code>, <code>inference_job_launcher.py</code>, <code>AWS_postprocess_runner.sh</code>, <code>calibrate.py</code>, several <code>preprocessing/</code> files, several <code>postprocessing/</code> files, several <code>batch/</code> files</td>
         </tr>
         <tr>
             <td><code>FLEPI_RESET_CHIMERICS</code></td>
             <td><code>-L</code>, <code>--reset_chimeric_on_accept</code></td>
             <td>Flag for whether or not chimeric parameters should be reset to global parameters whena  global acceptance occurs.</td>
-            <td><code>True</code></td>
+            <td><code>TRUE</code></td>
+            <td><code>--reset_chimeric_on_accept FALSE</code> for <code>FALSE</code>, <code>--reset_chimeric_on_accept</code> or no mention for <code>TRUE</code></td>
+            <td><code>flepimop-inference-slot.R</code>, <code>flepimop-inference-main.R</code>, <code>slurm_init.sh</code>, <code>hpc_init</code>, <code>inference_job_launcher.py</code></td>
         </tr>
         <tr>
             <td><code>FLEPI_RESUME</code></td>
             <td><code>--resume</code>/<code>--no-resume</code></td>
             <td>Flag for whether or not to resume the current calibration.</td>
-            <td><code>False</code></td>
+            <td><code>FALSE</code></td>
+            <td><code>--resume TRUE</code> for <code>TRUE</code>, <code>--resume</code> or no mention for <code>FALSE</code></td>
+            <td><code>flepimop-inference-slot.R</code>, <code>flepimop-inference-main.R</code>, <code>slurm_init.sh</code>, <code>hpc_init</code>, <code>inference_job_launcher.py</code></td>
         </tr>
         <tr>
             <td><code>FLEPI_RUN_INDEX</code></td>
             <td><code>-u</code>, <code>--run_id</code></td>
             <td>Unique ID given to the model run. If the same config is run multiple times, you can avoid the output being overwritten by using unique model run IDs.</td>
             <td>Auto-assigned run ID</td>
+            <td><code>int</code></td>
+            <td><code>copy_for_continuation.py</code>, <code>flepimop-inference-slot.R</code>, <code>flepimop-inference-main.R</code>, <code>shared_cli.py</code>, <code>base.py</code>, <code>calibrate.py</code>, several <code>batch/</code> files, several <code>postprocessing/</code> files</td>
         </tr>
         <tr>
             <td><code>FLEPI_SEIR_SCENARIOS</code></td>
             <td><code>-s</code>, <code>--seir_modifier_scenarios</code></td>
             <td>Names of the intervention scenarios to run.</td>
             <td><code>'all'</code></td>
+            <td><i>pending</i></td>
+            <td><code>flepimop-inference-slot.R</code>, <code>flepimop-inference-main.R</code>, <code>inference_job_launcher.py</code></td>
         </tr>
         <tr>
             <td><code>FLEPI_SLOT_INDEX</code></td>
             <td><code>-i</code>, <code>--this_slot</code></td>
             <td>Index for current slots.</td>
             <td><code>1</code></td>
-        </tr>
-        <tr>
-            <td><code>FLEPI_STOCHASTIC_RUN</code></td>
-            <td><code>-t</code>, <code>--stoch_traj_flag</code></td>
-            <td>Whether or not the model should be run stochastically or non-stochastically (deterministic numerical integration of equations using the RK4 algorithm)</td>
-            <td><code>False</code></td>
+            <td><code>int</code></td>
+            <td><code>flepimop-inference-slot.R</code>, several <code>batch/</code> files</td>
         </tr>
         <tr>
             <td><code>FS_RESULTS_PATH</code></td>
             <td><code>-R</code>, <code>--results-path</code></td>
             <td>A path to the model results.</td>
             <td>--</td>
+            <td><code>your/path/to/model_results</code></td>
+            <td><code>prune_by_llik.py</code>, <code>prune_by_llik_and_proj.py</code>, several <code>postprocessing/</code> files, several <code>batch/</code> files, <code>model_output_notebook.Rmd</code></td>
         </tr>
         <tr>
             <td><code>FULL_FIT</code></td>
             <td><code>-F</code>, <code>--full-fit</code></td>
             <td>Whether or not to process the full fit.</td>
-            <td><code>False</code></td>
+            <td><code>FALSE</code></td>
+            <td><code>--full-fit TRUE</code> for <code>TRUE</code>, <code>--full-fit</code> or no mention for <code>FALSE</code></td>
+            <td><code>run_sim_processing_SLURM.R</code></td>
         </tr>
         <tr>
             <td><code>GT_DATA_SOURCE</code></td>
             <td><code>-s</code>, <code>--gt_data_source</code></td>
             <td>Sources of groundtruth data.</td>
             <td><code>'csse_case, fluview_death, hhs_hosp'</code></td>
+            <td>See default</td>
+            <td><code>build_covid_data.R</code</td>
         </tr>
         <tr>
             <td><code>GT_END_DATE</code></td>
             <td><code>--ground_truth_end</code></td>
             <td>Last date to include ground truth for.</td>
             <td>--</td>
+            <td><code>YYYY-MM-DD</code> format</td>
+            <td><code>flepimop-inference-slot.R</code>, <code>flepimop-inference-main.R</code></td>
         </tr>
         <tr>
             <td><code>GT_START_DATE</code></td>
             <td><code>--ground_truth_start</code></td>
             <td>First date to include ground truth for.</td>
             <td>--</td>
+            <td><code>YYYY-MM-DD</code> format</td>
+            <td><code>flepimop-inference-slot.R</code>, <code>flepimop-inference-main.R</code></td>
         </tr>
         <tr>
             <td><code>IMM_ESC_PROP</code></td>
             <td><code>--imm_esc_prop</code></td>
             <td>Annual percent of immune escape.</td>
             <td><code>0.35</code></td>
+            <td><code>float</code> between <code>0.00 - 1.00</code></td>
+            <td>several <code>preprocessing/</code> files</td> <!-- Start here -->
         </tr>
         <tr>
             <td><code>INCL_AGGR_LIKELIHOOD</code></td>
             <td><code>-a</code>, <code>--incl_aggr_likelihood</code></td>
             <td>Whether or not the likelihood should be calculated with aggregate estimates.</td>
-            <td><code>False</code></td>
+            <td><code>FALSE</code></td>
+            <td><code>--incl_aggr_likelihood TRUE</code> for <code>TRUE</code>, <code>--incl_aggr_likelihood</code> or no mention for <code>FALSE</code></td>
+            <td><code>flepimop-inference-slot.R</code></td>
         </tr>
         <tr>
             <td><code>IN_FILENAME</code></td>
-            <td>N/A</td>
+            <td>Not a CL option.</td>
             <td>Name of input files.</td>
             <td>N/A</td>
+            <td><code>file_1.csv</code> <code>file_2.csv</code>, etc.</td> 
+            <td>several <code>batch/</code> files</td>
         </tr>
         <tr>
             <td><code>INIT_FILENAME</code></td>
             <td><code>--init_file_name</code></td>
             <td>Initial file global intermediate name.</td>
             <td>--</td>
+            <td><code>file.csv</code></td>
+            <td><code>seir_init_immuneladder.R</code>, <code>inference_job.run</code>, several <code>preprocessing/</code> files</td>
         </tr>
         <tr>
             <td><code>INTERACTIVE_RUN</code></td>
             <td><code>-I</code>, <code>--is-interactive</code></td>
             <td>Whether or not the current run is interactive.</td>
-            <td><code>False</code></td>
+            <td><code>FALSE</code></td>
+            <td><code>--is-interactive TRUE</code> for <code>TRUE</code>, <code>--is-interactive</code> or no mention for <code>FALSE</code></td>
+            <td><code>flepimop-inference-slot.R</code>, <code>flepimop-inference-main.R</code></td>
         </tr>
         <tr>
             <td><code>JOB_NAME</code></td>
             <td><code>--job-name</code></td>
             <td>Unique job name (intended for use when submitting to SLURM).</td>
             <td>--</td>
+            <td>Convention: <code>{config['name']}-{timestamp}</code> (str)</td>
+            <td>several <code>batch/</code> files</td>
         </tr>
         <tr>
             <td><code>LAST_JOB_OUTPUT</code></td>
-            <td>N/A</td>
+            <td>Not a CL option.</td>
             <td>Path to output of last job.</td>
             <td>N/A</td>
+            <td><code>path/to/last_job/output</code></td>
+            <td><code>utils.py</code>, several <code>batch/</code> files</td>
         </tr>
         <tr>
             <td><code>OLD_FLEPI_RUN_INDEX</code></td>
-            <td>N/A</td>
+            <td>Not a CL option.</td>
             <td>Run ID of old flepiMoP run.</td>
             <td>N/A</td>
+            <td><code>int</code></td>
+            <td>several <code>batch/</code> files</td>
         </tr>
         <tr>
             <td><code>OUT_FILENAME</code></td>
-            <td>N/A</td>
+            <td>Not a CL option.</td>
             <td>Name of output files.</td>
             <td>N/A</td>
+            <td><code>file_1.csv</code> <code>file_2.csv</code>, etc.</td>
+            <td>several <code>batch/</code> files</td>
         </tr>
         <tr>
             <td><code>OUT_FILENAME_DIR</code></td>
-            <td>N/A</td>
+            <td>Not a CL option.</td>
             <td>Directory for output files.</td>
             <td>N/A</td>
+            <td><code>path/to/output/files</code></td>
+            <td><code>SLURM_inference_job.run</code></td>
         </tr>
         <tr>
             <td><code>OUTPUTS</code></td>
             <td><code>-o</code>, <code>--select-outputs</code></td>
             <td>A list of outputs to plot.</td>
             <td><code>'hosp, hnpi, snpi, llik'</code></td>
+            <td><code>hosp, hnpi, snpi, llik</code></td>
+            <td><code>postprocess_snapshot.R</code></td>
         </tr>
         <tr>
             <td><code>PARQUET_TYPES</code></td>
-            <td>N/A</td>
+            <td>Not a CL option.</td>
             <td>Parquet files.</td>
             <td><code>'seed spar snpi seir hpar hnpi hosp llik init'</code></td>
+            <td><code>seed spar snpi seir hpar hnpi hosp llik init</code></td>
+            <td><code>AWS_postprocess_runner.sh</code>, <code>SLURM_inference_job.run</code>, <code>AWS_inference_runner.sh</code></td>
         </tr>
         <tr>
             <td><code>PATH</code></td>
-            <td>N/A</td>
+            <td>Not a CL option.</td>
             <td>Path relating to AWS installation. Used during SLURM runs.</td>
             <td>N/A</td>
+            <td>set with <code>export PATH=~/aws-cli/bin:$PATH</code> in <code>SLURM_inference_job.run</code></td>
+            <td><code>schema.yml</code>, <code>utils.py</code>, <code>info.py</code>, <code>AWS_postprocess_runner.sh</code>, <code>SLURM_inference_job.run</code></td>
         </tr>
         <tr>
             <td><code>PROCESS</code></td>
             <td><code>-r</code>, <code>--run-processing</code></td>
             <td>Whether or not to process the run.</td>
-            <td><code>False</code></td>
+            <td><code>FALSE</code></td>
+            <td><code>--run-processing TRUE</code> for <code>TRUE</code>, <code>--run-processing</code> or no mention for <code>FALSE</code></td>
+            <td><code>run_sim_processing_SLURM.R</code></td>
         </tr>
         <tr>
             <td><code>PROJECT_PATH</code></td>
             <td><code>-d</code>, <code>--data_path</code></td>
             <td>Path to the folder with configs and model output.</td>
             <td>--</td>
+            <td><code>path/to/configs_and_model-output</code></td>
+            <td><code>base.py</code>, <code>_cli.py</code>, <code>calibrate.py</code>, several <code>postprocessing/</code> files, several <code>batch/</code> files</td>
         </tr>
         <tr>
             <td><code>PULL_GT</code></td>
             <td><code>-g</code>, <code>--pull-gt</code></td>
             <td>Whether or not to pull ground truth data.</td>
-            <td><code>False</code></td>
+            <td><code>FALSE</code></td>
+            <td><code>--pull-gt TRUE</code> for <code>TRUE</code>, <code>--pull-gt</code> or no mention for <code>FALSE</code></td>
+            <td><code>run_sm_processing_SLURM.R</code></td>
         </tr>
         <tr>
             <td><code>PYTHON_PATH</code></td>
             <td><code>-y</code>, <code>--python</code></td>
             <td>Path to Python executable.</td>
             <td><code>'python3'</code></td>
+            <td><code>path/to/your_python</code></td>
+            <td><code>flepimop-inference-slot.R</code>, <code>flepimop-inference-main.R</code></td>
         </tr>
         <tr>
             <td><code>RESUMED_CONFIG_PATH</code></td>
             <td><code>--res_config</code></td>
             <td>Path to previous config file, if using resumes.</td>
             <td><code>NA</code></td>
+            <td><code>path/to/past_config</code></td>
+            <td><code>seir_init_immuneladder.R</code>, several <code>preprocessing/</code> files</td>
         </tr>
         <tr>
             <td><code>RESUME_DISCARD_SEEDING</code></td>
             <td><code>--resume-discard-seeding</code>, <code>--resume-carry-seeding</code></td>
             <td>Whether or not to keep seeding in resume runs.</td>
-            <td><code>False</code></td>
+            <td><code>FALSE</code></td>
+            <td><code>--resume-carry-seeding TRUE</code> for <code>TRUE</code>, <code>--resume-carry-seeding</code> or no mention for <code>FALSE</code></td>
+            <td>several <code>batch/</code> files</td>
         </tr>
         <tr>
             <td><code>RESUME_LOCATION</code></td>
             <td><code>-r</code>, <code>--restart-from-location</code></td>
             <td>The location (folder or an S3 bucket) where the previous run is stored.</td>
             <td>--</td>
+            <td><code>path/to/last_job/output</code></td>
+            <td><code>built_initial_seeding.R</code>, <code>calibrate.py</code>, <code>slurm_init.sh</code>, <code>hpc_init</code>, <code>inference_job_launcher.py</code></td>
         </tr>
         <tr>
             <td><code>RESUME_RUN</code></td>
             <td><code>-R</code>, <code>--is-resume</code></td>
             <td>Whether or not this run is a resume.</td>
-            <td><code>False</code></td>
+            <td><code>FALSE</code></td>
+            <td><code>--is-a-resume TRUE</code> for <code>TRUE</code>, <code>--is-a-resume</code> or no mention for <code>FALSE</code></td>
+            <td><code>flepimop-inference-slot.R</code>, <code>flepimop-inference-main.R</code></td>
+        </tr>
+        <tr>
+            <td><code>RESUME_RUN_INDEX</code></td>
+            <td>Not a CL option.</td>
+            <td>Index of resumed run.</td>
+            <td>set by <code>OLD_FLEPI_RUN_INDEX</code></td>
+            <td><code>int</code></td>
+            <td><code>SLURM_inference_job.run</code></td>
         </tr>
         <tr>
             <td><code>RSCRIPT_PATH</code></td>
             <td><code>-r</code>, <code>--rpath</code></td>
             <td>Path to R executable.</td>
             <td><code>'Rscript'</code></td>
+            <td><code>path/to/your_R</code></td>
+            <td><code>build_initial_seeding.R</code>, <code>flepimop-inference-slot.R</code>, <code>flepimop-inference-main.R</code></td>
         </tr>
         <tr>
             <td><code>RUN_INTERACTIVE</code></td>
             <td><code>-I</code>, <code>--is-interactive</code></td>
             <td>Whether or not the current run is interactive.</td>
-            <td><code>False</code></td>
+            <td><code>FALSE</code></td>
+            <td><code>--is-interactive</code> for <code>TRUE</code>, <code>--is-interactive</code> or no mention for <code>FALSE</code></td>
+            <td><code>flepimop-inference-slot.R</code>, <code>flepimop-inference-main.R</code></td>
         </tr>
         <tr>
             <td><code>SAVE_HOSP</code></td>
             <td><code>-H</code>, <code>--save_hosp</code></td>
             <td>Whether or not the HOSP output files should be saved for each iteration.</td>
-            <td><code>True</code></td>
+            <td><code>TRUE</code></td>
+            <td><code>--save_hosp FALSE</code> for <code>FALSE</code>, <code>--save_hosp</code> or no mention for <code>TRUE</code></td>
+            <td><code>flepimop-inference-slot.R</code>, <code>flepimop-inference-main.R</code></td>
         </tr>
         <tr>
             <td><code>SAVE_SEIR</code></td>
             <td><code>-S</code>, <code>--save_seir</code></td>
             <td>Whether or not the SEIR output files should be saved for each iteration.</td>
-            <td><code>False</code></td>
+            <td><code>FALSE</code></td>
+            <td><code>--save_seir TRUE</code> for <code>TRUE</code>, <code>--save_seir</code> or no mention for <code>FALSE</code></td>
+            <td><code>flepimop-inference-slot.R</code>, <code>flepimop-inference-main.R</code></td>
         </tr>
         <tr>
             <td><code>SEED_VARIANTS</code></td>
             <td><code>-s</code>, <code>--seed_variants</code></td>
             <td>Whether or not to add variants/subtypes to outcomes in seeding.</td>
             <td>--</td>
+            <td><code>FALSE</code>, <code>TRUE</code></td>
+            <td><code>create_seeding.R</code></td>
         </tr>
         <tr>
             <td><code>SIMS_PER_JOB</code></td>
-            <td>N/A</td>
+            <td>Not a CL option.</td>
             <td>Simulations per job.</td>
             <td>N/A</td>
+            <td><code>int >=1</code></td>
+            <td><code>AWS_postprocess_runner.sh</code>, <code>inference_job_launcher.py</code>, <code>AWS_inference_runner.sh</code></td>
         </tr>
         <tr>
             <td><code>SLACK_CHANNEL</code></td>
             <td><code>-s</code>, <code>--slack-channel</code></td>
             <td>Slack channel, either 'csp-production' or 'debug'; or 'noslack' to disable slack.</td>
             <td>--</td>
+            <td><code>csp-production</code>, <code>debug</code>, or <code>noslack</code></td>
+            <td><code>postrpocess_auto.py</code>, <code>postprocessing-scripts.sh</code>, <code>inference_job_launcher.py</code></td>
         </tr>
         <tr>
             <td><code>SLACK_TOKEN</code></td>
             <td><code>-s</code>, <code>--slack-token</code></td>
             <td>Slack token.</td>
             <td>--</td>
+            <td><a href="https://api.slack.com/tutorials/tracks/getting-a-token">How to get a Slack token</a></td>
+            <td><code>postprocess_auto.py</code>, <code>SLURM_postprocess_runner.run</code></td>
         </tr>
         <tr>
             <td><code>SUBPOP_LENGTH</code></td>
             <td><code>-g</code>, <code>--subpop_len</code></td>
             <td>Number of digits in subpops.</td>
             <td><code>5</code></td>
+            <td><code>int</code></td>
+            <td><code>flepimop-inference-slot.R</code>, <code>flepimop-inference-main.R</code></td>
         </tr>
         <tr>
             <td><code>S3_MODEL_PROJECT_PATH</code></td>
-            <td>N/A</td>
+            <td>Not a CL option.</td>
             <td>Location in S3 bucket with the code, data, and dvc pipeline.</td>
             <td>N/A</td>
+            <td><code>path/to/code_data_dvc</code></td>
+            <td>several <code>batch/</code> files</td>
         </tr>
         <tr>
             <td><code>S3_RESULTS_PATH</code></td>
-            <td>N/A</td>
+            <td>Not a CL option.</td>
             <td>Location in S3 to store results.</td>
             <td>N/A</td>
+            <td><code>path/to/s3/results</code></td>
+            <td>several <code>batch/</code> files</td>
         </tr>
         <tr>
             <td><code>S3_UPLOAD</code></td>
-            <td>N/A</td>
-            <td>Whether or not to upload S3 buckets.</td>
-            <td>N/A</td>
+            <td>Not a CL option.</td>
+            <td>Whether or not we also save runs to S3 for slurm runs</td>
+            <td><code>TRUE</code></td>
+            <td><code>TRUE</code>, <code>FALSE</code></td>
+            <td><code>SLURM_postprocess_runner.run</code>, <code>SLURM_inference_job.run</code>, <code>inference_job_launcher.py</code></td>
         </tr>
         <tr>
             <td><code>VALIDATION_DATE</code></td>
             <td><code>--validation-end-date</code></td>
             <td>First date of projection/forecast (first date without ground truth data).</td>
             <td><code>date.today()</code></td>
+            <td><code>YYYY-MM-DD</code> format</td>
+            <td><code>data_setup_source.R</code>, <code>DataUtils.R</code>, <code>groundtruth_source.R</code>, <code>slurm_init.sh</code>, <code>hpc_init</code>, <code>inference_job_launcher.py</code></td>
         </tr>
     </tbody>
 </table>
-
-
-
-
-
-
-
-
-

--- a/flepimop/gempyor_pkg/src/gempyor/calibrate.py
+++ b/flepimop/gempyor_pkg/src/gempyor/calibrate.py
@@ -1,7 +1,7 @@
 """
-Facilitates the calibration of the model using the `emcee` MCMC sampler. 
+Facilitates the calibration of the model using the `emcee` MCMC sampler.
 
-Provides CLI options for users to specify simulation parameters. 
+Provides CLI options for users to specify simulation parameters.
 
 Functions:
     calibrate: Reads a configuration file for simulation settings.

--- a/flepimop/gempyor_pkg/src/gempyor/compartments.py
+++ b/flepimop/gempyor_pkg/src/gempyor/compartments.py
@@ -1,17 +1,17 @@
 """
-Defines class, methods, and functions necessary to establising compartments in the model. 
+Defines class, methods, and functions necessary to establising compartments in the model.
 
 Classes:
-    Compartments: An object to handle compartment data for the model. 
+    Compartments: An object to handle compartment data for the model.
 
 Functions:
     get_list_dimension: Returns length of object passed (if a list); otherwise returns 1.
     list_access_element_safe: Attempts to access something from the given object at specified index.
     list_access_element: Attempts to access soemthing from the given object at specified index.
-    list_recursive_convert_to_string: Convert item(s) in object to str(s). 
-    compartments: A container for subcommands related to the compartmental model. 
-    plot: Generate a plot representing transition between compartments. 
-    export: Export compartment data to a CSV file. 
+    list_recursive_convert_to_string: Convert item(s) in object to str(s).
+    compartments: A container for subcommands related to the compartmental model.
+    plot: Generate a plot representing transition between compartments.
+    export: Export compartment data to a CSV file.
 """
 
 import logging

--- a/flepimop/gempyor_pkg/src/gempyor/inference.py
+++ b/flepimop/gempyor_pkg/src/gempyor/inference.py
@@ -10,21 +10,21 @@
 
 """
 Classes:
-    GempyorInference: 
+    GempyorInference:
         Encapsulates the process of simulation. Provides functionality for parameter
         inference, SEIR model execution, outcome computation, and inference optimization.
 
 Functions:
-    simulation_atomic: 
+    simulation_atomic:
         Runs a SEIR simulation (generates and reduces parameters, executes SEIR
         processes, computes outcomes, handles NPIs and seeding data).
     get_static_arguments: Get the static arguments for the log likelihood function.
     autodetect_senarios: Auto-detect the scenarios provided in config.
-    paramred_parallel: 
-        Initializes a `GempyorInference` object with a configuration file, 
+    paramred_parallel:
+        Initializes a `GempyorInference` object with a configuration file,
         reads specified NPI file, and computes reduced SEIR model specifications
         based on this info. Returns the reduced parameters.
-    paramred_parallel_config: 
+    paramred_parallel_config:
         Initializes a `GempyorInference` object with a configuration file,
         retreives SEIR model specifications and NPIs, and computes reduced
         parameters based on this info. Returns the reduced parameters.

--- a/flepimop/gempyor_pkg/src/gempyor/info.py
+++ b/flepimop/gempyor_pkg/src/gempyor/info.py
@@ -1,13 +1,13 @@
 """
 Retrieving static information from developer managed yaml files.
 
-Currently, it includes utilities for handling cluster-specific information, but it can 
+Currently, it includes utilities for handling cluster-specific information, but it can
 be extended to other categories as needed.
 
 Classes:
     Module: Represents a software module with a name and optional version.
     PathExport: Represents a path export with a path, prepend flag, and error handling.
-    Cluster: Represents a cluster with a name, list of modules, and list of path 
+    Cluster: Represents a cluster with a name, list of modules, and list of path
         exports.
 
 Functions:
@@ -15,17 +15,17 @@ Functions:
 
 Notes:
     By default the order for search paths is:
-    
+
     1) The current working directory, then
     2) The directory specified by the `$FLEPI_INFO_PATH` environment variable if set,
        and finally
     3) The directory specified by the `$FLEPI_PATH` environment variable if set.
-    
+
     The functions in this module will search for an `info/` directory under the search
     paths with a structure of `info/<category>/<name>.yml` where `<category>` is the
     category of the information and `<name>` is the name of the information. The first
     yaml file found will be used to populate the model.
-    
+
     The default search paths can be overridden by passing a list of paths to the
     function being used via the `search_paths` argument.
 

--- a/flepimop/gempyor_pkg/src/gempyor/logging.py
+++ b/flepimop/gempyor_pkg/src/gempyor/logging.py
@@ -1,9 +1,9 @@
 """
 Logging utilities for consistent script output.
 
-This module provides functionality for creating consistent outputs from CLI tools 
+This module provides functionality for creating consistent outputs from CLI tools
 provided by this package. Currently exported are:
-- `ClickHandler`: Custom logging handler specifically designed for CLI output using 
+- `ClickHandler`: Custom logging handler specifically designed for CLI output using
     click.
 - `get_script_logger`: Factory for creating a logger instance with a consistent style
     across CLI tools.

--- a/flepimop/gempyor_pkg/src/gempyor/model_info.py
+++ b/flepimop/gempyor_pkg/src/gempyor/model_info.py
@@ -1,11 +1,11 @@
 """
 Abstractions for interacting with models as a monolithic object.
 
-Defines the `ModelInfo` class (and associated methods), used for setting up and 
+Defines the `ModelInfo` class (and associated methods), used for setting up and
 managing the configuration of a simulation. The primary focuses of a `ModelInfo` object
-are parsing and validating config details (including time frames, subpop info, 
-model parameters, outcomes) and file handling for input and output data. 
-This submodule is intended to serve as a foundational part of flepiMoP's 
+are parsing and validating config details (including time frames, subpop info,
+model parameters, outcomes) and file handling for input and output data.
+This submodule is intended to serve as a foundational part of flepiMoP's
 infrastructure for conducting simulations and storing results.
 
 Classes:

--- a/flepimop/gempyor_pkg/src/gempyor/parameters.py
+++ b/flepimop/gempyor_pkg/src/gempyor/parameters.py
@@ -2,7 +2,7 @@
 Provides abstractions for interacting with the parameters configurations.
 
 Classes:
-    Parameters: 
+    Parameters:
         Encapsulates logic for loading, parsing, and summarizing parameter configurations.
 """
 

--- a/flepimop/gempyor_pkg/src/gempyor/shared_cli.py
+++ b/flepimop/gempyor_pkg/src/gempyor/shared_cli.py
@@ -47,7 +47,7 @@ config_file_options = {
     ),
     "seir_modifiers_scenarios": click.Option(
         ["-s", "--seir_modifiers_scenarios"],
-        envvar="FLEPI_SEIR_SCENARIO",
+        envvar="FLEPI_SEIR_SCENARIOS",
         type=click.STRING,
         default=[],
         multiple=True,
@@ -55,7 +55,7 @@ config_file_options = {
     ),
     "outcome_modifiers_scenarios": click.Option(
         ["-d", "--outcome_modifiers_scenarios"],
-        envvar="FLEPI_OUTCOME_SCENARIO",
+        envvar="FLEPI_OUTCOME_SCENARIOS",
         type=click.STRING,
         default=[],
         multiple=True,

--- a/flepimop/gempyor_pkg/tests/parameters/test_parameters_class.py
+++ b/flepimop/gempyor_pkg/tests/parameters/test_parameters_class.py
@@ -192,7 +192,7 @@ def insufficient_dates_parameter_factory(tmp_path: pathlib.Path) -> MockParamete
 
 
 class TestParameters:
-    @pytest.mark.parametrize("factory", [(nonunique_invalid_parameter_factory)])
+    @pytest.mark.parametrize("factory", [nonunique_invalid_parameter_factory])
     def test_nonunique_parameter_names_value_error(
         self,
         tmp_path: pathlib.Path,
@@ -208,7 +208,7 @@ class TestParameters:
         ):
             mock_inputs.create_parameters_instance()
 
-    @pytest.mark.parametrize("factory", [(insufficient_columns_parameter_factory)])
+    @pytest.mark.parametrize("factory", [insufficient_columns_parameter_factory])
     def test_timeseries_parameter_has_insufficient_columns_value_error(
         self,
         tmp_path: pathlib.Path,
@@ -244,7 +244,7 @@ class TestParameters:
         ):
             mock_inputs.create_parameters_instance()
 
-    @pytest.mark.parametrize("factory", [(insufficient_dates_parameter_factory)])
+    @pytest.mark.parametrize("factory", [insufficient_dates_parameter_factory])
     def test_timeseries_parameter_has_insufficient_dates_value_error(
         self,
         tmp_path: pathlib.Path,

--- a/flepimop/gempyor_pkg/tests/statistics/test_statistic_class.py
+++ b/flepimop/gempyor_pkg/tests/statistics/test_statistic_class.py
@@ -313,7 +313,7 @@ all_valid_factories = [
 
 
 class TestStatistic:
-    @pytest.mark.parametrize("factory", [(invalid_regularization_factory)])
+    @pytest.mark.parametrize("factory", [invalid_regularization_factory])
     def test_unsupported_regularizations_value_error(
         self, factory: Callable[[], MockStatisticInput]
     ) -> None:
@@ -618,7 +618,7 @@ class TestStatistic:
                 ),
             )
 
-    @pytest.mark.parametrize("factory", [(invalid_misshaped_data_factory)])
+    @pytest.mark.parametrize("factory", [invalid_misshaped_data_factory])
     def test_compute_logloss_data_misshape_value_error(
         self, factory: Callable[[], MockStatisticInput]
     ) -> None:

--- a/postprocessing/postprocess_snapshot.R
+++ b/postprocessing/postprocess_snapshot.R
@@ -21,7 +21,7 @@ option_list = list(
   optparse::make_option(c("-u","--run-id"), action="store", dest = "run_id", type='character', help="Unique identifier for this run", default = Sys.getenv("FLEPI_RUN_INDEX",flepicommon::run_id())),
   optparse::make_option(c("-R", "--results-path"), action="store", dest = "results_path",  type='character', help="Path for model output", default = Sys.getenv("FS_RESULTS_PATH", Sys.getenv("FS_RESULTS_PATH"))),
   # optparse::make_option(c("-p", "--flepimop-repo"), action="store", dest = "flepimop_repo", default=Sys.getenv("FLEPI_PATH", Sys.getenv("FLEPI_PATH")), type='character', help="path to the flepimop repo"),
-  optparse::make_option(c("-o", "--select-outputs"), action="store", dest = "select_outputs", default=Sys.getenv("OUTPUTS","hosp, hnpi, snpi, llik"), type='character', help="path to the flepimop repo")
+  optparse::make_option(c("-o", "--select-outputs"), action="store", dest = "select_outputs", default=Sys.getenv("OUTPUTS","hosp, hnpi, snpi, llik"), type='character', help="A list of outputs to plot.")
 )
 
 parser=optparse::OptionParser(option_list=option_list)


### PR DESCRIPTION
### Describe your changes.

This PR creates a new file (`environmental-variables.md`) in the gitbook that attempts to consolidate documentation on the environmental variables used throughout flepiMoP. A few notes: 
1) I omitted documentation for a handful of envvars that just appear in documentation, but not actually in the codebase. We can work on removing this deprecated documentation with another issue. 

2) I made some adjustments to envvars in the codebase; either fixing descriptions or reconciling redundant envvars.

3) I have a lurking (and strong) suspicion that there are still some sneaky ones I did not track down yet, so those remain undocumented but this can be an ongoing effort. All of the envvars that are set by users should be in here (i.e., the envvars still at large are created and set in the codebase with no user input). Also, the idea is that we move towards having fewer envvars, so as we begin to prune those away we will have to update this documentation page anyways. 

4) I'm not sure how useful the `Key file locations` column is, because it doesn't necessarily point to where the envvar's value is getting used in the code, it just points to occurrence of that particular envvar.

Here are the envvars that I think should be inspected first, with the intent to prune:

- `COMPUTE_QUEUE`, `RESUME_S3`, `CONFIG_NAME`, `COVID_RESET_CHIMERICS`, `INTERVENTION_NAME`, `COVID_RUN_INDEX`, `COVID_MAX_STACK_SIZE`, `JOB_ID`, `COVID_PATH`, `SLACK_WEBHOOK` because it seems like they only exist in documentation, not in the codebase.
- Recconcile `RUN_INTERACTIVE` and `INTERACTIVE_RUN` (They do the same thing I think...)
- `FLEPI_PREFIX` seems redundant with `FLEPI_RUN_INDEX`, or perhaps `JOB_NAME`

### What does your pull request address? Tag relevant issues.

This pull request addresses GH #491 

