### PR TITLE
patch in simulations being able to select subpops

### DIFF
--- a/documentation/gitbook/gempyor/model-implementation/specifying-population-structure.md
+++ b/documentation/gitbook/gempyor/model-implementation/specifying-population-structure.md
@@ -30,13 +30,12 @@ subpop_setup:
 | ----------- | ------------ | ------------ | ------------------------------------- |
 | geodata     | **required** | path to file | path to geodata file                  |
 | mobility    | **required** | path to file | path to mobility file                 |
-| selected    | **optional** | string       | name of selected location in`geodata` |
+| selected    | **optional** | string or list of strings       | name of selected location in`geodata` |
 
-### `geodata` file
+### `geodata` file and `selected` option
 
 * `geodata` is a .csv with column headers, with at least two columns: `subpop` and `population`.
-* `nodenames` is the name of a column in `geodata` that specifies unique geographical identification strings for each subpopulation.
-* `selected` is the list of selected locations in geodata to be modeled
+* `selected` if provided, is the subset of locations in geodata file (as determined by `subpop` column) to be modeled. Requesting subpopulation(s) that are not present will lead to an error.
 
 #### Example geodata file format
 
@@ -48,7 +47,7 @@ subpop,population
 
 ### `mobility` file
 
-The `mobility` file is a .csv file (it has to contain .csv as extension) with long form comma separated values. Columns have to be named `ori`, `dest`, `amount,` with amount being the average number individuals moving from the origin subpopulation `ori` to destination subpopulation `dest` on any given day. Details on the mathematics of this model of contact are explained in the [Model Description section](../model-description.md#mixing-between-subpopulations). Unassigned relations are assumed to be zero. The location entries in the `ori` and `dest` columns should match exactly the `subpop` column in `geodata.csv`
+The `mobility` file is a .csv file (it has to contain .csv as extension) with long form comma separated values. Columns have to be named `ori`, `dest`, `amount,` with amount being the average number individuals moving from the origin subpopulation `ori` to destination subpopulation `dest` on any given day. Details on the mathematics of this model of contact are explained in the [Model Description section](../model-description.md#mixing-between-subpopulations). Unassigned relations are assumed to be zero. The location entries in the `ori` and `dest` columns should correspond to an entry in the `subpop` column in `geodata.csv`. When using `selected`, the `mobility` data will also be filtered.
 
 #### Example mobility file format
 

--- a/documentation/gitbook/gempyor/model-implementation/specifying-population-structure.md
+++ b/documentation/gitbook/gempyor/model-implementation/specifying-population-structure.md
@@ -27,9 +27,9 @@ subpop_setup:
 ## Items and options
 
 | Config Item | Required?    | Type/Format  | Description                           |
-| ----------- | ------------ | ------------ | ------------------------------------- |
-| geodata     | **required** | path to file | path to geodata file                  |
-| mobility    | **required** | path to file | path to mobility file                 |
+| ----------- | ------------ | ------------------------------- | ------------------------------------- |
+| geodata     | **required** | path to file                    | path to geodata file                  |
+| mobility    | **required** | path to file                    | path to mobility file                 |
 | selected    | **optional** | string or list of strings       | name of selected location in`geodata` |
 
 ### `geodata` file and `selected` option

--- a/examples/tutorials/config_sample_2pop_stochastic.yml
+++ b/examples/tutorials/config_sample_2pop_stochastic.yml
@@ -2,7 +2,7 @@ name: sample_2pop
 setup_name: stochastic
 start_date: 2020-02-01
 end_date: 2020-08-31
-nslots: 1
+nslots: 20
 
 subpop_setup:
   geodata: model_input/geodata_sample_2pop.csv
@@ -20,7 +20,7 @@ compartments:
 seir:
   integration:
     method: stochastic
-    dt: 1
+    dt: 0.2
   parameters:
     sigma:
       value: 1 / 4

--- a/flepimop/gempyor_pkg/src/gempyor/shared_cli.py
+++ b/flepimop/gempyor_pkg/src/gempyor/shared_cli.py
@@ -299,9 +299,10 @@ def parse_config_files(
         )
 
     if (populations := kwargs.pop("populations", None)) is not None:
-        cfg["subpop_setup"]["selected"].set(
-            list(_parse_option(config_file_options["populations"], populations))
-        )
+        if populations:
+            cfg["subpop_setup"]["selected"].set(
+                list(_parse_option(config_file_options["populations"], populations))
+            )
 
     for option in other_args:
         if (value := kwargs.get(option)) is not None:

--- a/flepimop/gempyor_pkg/src/gempyor/shared_cli.py
+++ b/flepimop/gempyor_pkg/src/gempyor/shared_cli.py
@@ -298,7 +298,7 @@ def parse_config_files(
             _parse_option(config_file_options["method"], method)
         )
 
-    if populations := kwargs.pop("populations", None):
+    if (populations := kwargs.pop("populations", None)) is not None:
         cfg["subpop_setup"]["selected"].set(
             list(_parse_option(config_file_options["populations"], populations))
         )

--- a/flepimop/gempyor_pkg/src/gempyor/shared_cli.py
+++ b/flepimop/gempyor_pkg/src/gempyor/shared_cli.py
@@ -45,6 +45,13 @@ config_file_options = {
         multiple=True,
         help="Deprecated: configuration file(s) for this simulation",
     ),
+    "populations": click.Option(
+        ["-p", "--populations", "populations"],
+        type=click.STRING,
+        required=False,
+        multiple=True,
+        help="Population(s) to run use in simulation.",
+    ),
     "seir_modifiers_scenarios": click.Option(
         ["-s", "--seir_modifiers_scenarios"],
         envvar="FLEPI_SEIR_SCENARIO",
@@ -287,14 +294,14 @@ def parse_config_files(
     other_args = parsed_args - config_args - scen_args
 
     if method := kwargs.pop("method", None):
-        print(
-            f"saw method! {method} vs {_parse_option(config_file_options['method'], method)}"
-        )
         cfg["seir"]["integration"]["method"].set(
             _parse_option(config_file_options["method"], method)
         )
-        print(f"set method! {cfg['seir']['integration']['method']}")
-        print(f"check exists {cfg['seir']['integration'].exists()}")
+
+    if populations := kwargs.pop("populations", None):
+        cfg["subpop_setup"]["selected"].set(
+            list(_parse_option(config_file_options["populations"], populations))
+        )
 
     for option in other_args:
         if (value := kwargs.get(option)) is not None:

--- a/flepimop/gempyor_pkg/tests/shared_cli/test_parse_config_files.py
+++ b/flepimop/gempyor_pkg/tests/shared_cli/test_parse_config_files.py
@@ -66,7 +66,7 @@ def good_opt_args(opt: str) -> dict[str, Any]:
             "in_run_id": "foo",
             "out_run_id": "foo",
             "in_prefix": "foo",
-            "populations": "test"
+            "populations": "test",
         }[opt]
     }
 
@@ -86,7 +86,7 @@ def ref_cfg_kvs(opt: str) -> dict[str, Any]:
             "in_run_id": "bar",
             "out_run_id": "bar",
             "in_prefix": "bar",
-            "populations": ["reference"]
+            "populations": ["reference"],
         }[opt]
     }
 

--- a/flepimop/gempyor_pkg/tests/shared_cli/test_parse_config_files.py
+++ b/flepimop/gempyor_pkg/tests/shared_cli/test_parse_config_files.py
@@ -66,6 +66,7 @@ def good_opt_args(opt: str) -> dict[str, Any]:
             "in_run_id": "foo",
             "out_run_id": "foo",
             "in_prefix": "foo",
+            "populations": "test"
         }[opt]
     }
 
@@ -85,6 +86,7 @@ def ref_cfg_kvs(opt: str) -> dict[str, Any]:
             "in_run_id": "bar",
             "out_run_id": "bar",
             "in_prefix": "bar",
+            "populations": ["reference"]
         }[opt]
     }
 
@@ -192,6 +194,8 @@ class TestParseConfigFiles:
         for k, v in refopt.items():
             if k == "method":
                 assert mockconfig["seir"]["integration"][k].get(v) == v
+            elif k == "populations":
+                assert mockconfig["subpop_setup"]["selected"].get(v) == v
             else:
                 assert mockconfig[k].get(v) == v
         mockconfig.clear()


### PR DESCRIPTION
This pull request adds the ability to select target subpopulation for simulation.

It adds an option to the simulate CLI interface, which is self-documenting in shared_cli.py