### PR TITLE
Fix empty import in `gempyor.sync._sync`

### DIFF
--- a/flepimop/gempyor_pkg/src/gempyor/sync/_sync.py
+++ b/flepimop/gempyor_pkg/src/gempyor/sync/_sync.py
@@ -15,7 +15,7 @@ from pydantic import (
     model_validator,
 )
 
-from .._pydantic_ext import *
+from .._pydantic_ext import _override_or_val
 from ._sync_filter import ListSyncFilter, WithFilters, FilterParts
 
 __all__ = ["sync_from_yaml", "sync_from_dict"]


### PR DESCRIPTION
### Describe your changes.

Wildcard import from internal module imported nothing, change to explicitly import required function `_override_or_val`. This hot fix makes the `flepimop sync` CLI tool work for rsync and S3 instead of producing an error like:
```
[twillard@longleaf-login4 tutorials]$ cat slurm-66249381_1.out
Traceback (most recent call last):
  File "/nas/longleaf/home/twillard/.conda/envs/flepimop-env/bin/flepimop", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/nas/longleaf/home/twillard/.conda/envs/flepimop-env/lib/python3.11/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nas/longleaf/home/twillard/.conda/envs/flepimop-env/lib/python3.11/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/nas/longleaf/home/twillard/.conda/envs/flepimop-env/lib/python3.11/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nas/longleaf/home/twillard/.conda/envs/flepimop-env/lib/python3.11/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nas/longleaf/home/twillard/.conda/envs/flepimop-env/lib/python3.11/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nas/longleaf/home/twillard/.conda/envs/flepimop-env/lib/python3.11/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/users/t/w/twillard/flepiMoP/flepimop/gempyor_pkg/src/gempyor/sync/sync.py", line 125, in sync
    return sync_from_yaml(config_files, kwargs, verbosity).returncode
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/users/t/w/twillard/flepiMoP/flepimop/gempyor_pkg/src/gempyor/sync/_sync.py", line 323, in sync_from_yaml
    return sync_from_dict(syncdef, opts, verbosity)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/users/t/w/twillard/flepiMoP/flepimop/gempyor_pkg/src/gempyor/sync/_sync.py", line 336, in sync_from_dict
    return SyncProtocols(**syncdef).execute(SyncOptions(**opts), verbosity)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nas/longleaf/home/twillard/.conda/envs/flepimop-env/lib/python3.11/functools.py", line 946, in _method
    return method.__get__(obj, cls)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/users/t/w/twillard/flepiMoP/flepimop/gempyor_pkg/src/gempyor/sync/_sync.py", line 90, in _sync_impl
    return self._sync_pydantic(sync_options, verbosity)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/users/t/w/twillard/flepiMoP/flepimop/gempyor_pkg/src/gempyor/sync/_sync.py", line 294, in _sync_pydantic
    return proto.execute(sync_options, verbosity)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nas/longleaf/home/twillard/.conda/envs/flepimop-env/lib/python3.11/functools.py", line 946, in _method
    return method.__get__(obj, cls)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/users/t/w/twillard/flepiMoP/flepimop/gempyor_pkg/src/gempyor/sync/_sync.py", line 90, in _sync_impl
    return self._sync_pydantic(sync_options, verbosity)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/work/users/t/w/twillard/flepiMoP/flepimop/gempyor_pkg/src/gempyor/sync/_sync.py", line 140, in _sync_pydantic
    str(_override_or_val(sync_options.source_override, self.source)) + "/",
        ^^^^^^^^^^^^^^^^
NameError: name '_override_or_val' is not defined
```

### Does this pull request make any user interface changes? If so please describe.

The user interface changes are none, this is PR just fixes the currently broken `flepimop sync` CLI tool.