### PR TITLE
Fix flaky `fix_parameter_positivity()` test

### DIFF
--- a/flepimop/gempyor_pkg/tests/seir/test_seir.py
+++ b/flepimop/gempyor_pkg/tests/seir/test_seir.py
@@ -63,9 +63,11 @@ def test_check_parameter_positivity():
         (len(parameter_names) - 1, len(dates) - 1, len(subpop_names) - 1)
     )
     for _ in range(5):
-        test_array2[randint(0, len(parameter_names) - 1)][randint(0, len(dates) - 1)][
-            randint(0, len(subpop_names) - 1)
-        ] = -1
+        param_idx = np.random.randint(0, test_array2.shape[0])
+        date_idx = np.random.randint(0, test_array2.shape[1])
+        subpop_idx = np.random.randint(0, test_array2.shape[2])
+        test_array2[param_idx, date_idx, subpop_idx] = -1
+
     test_2_negative_index_parameters = np.argwhere(test_array2 < 0)
     test_2_neg_params = []
     test_2_neg_subpops = []


### PR DESCRIPTION
### Describe your changes.

Occasionally, the `check_parameter_positivity()` test function in `test_seir.py` was throwing an `IndexError` when the `randint()` call was calling a index for the test array that was out of bounds. I altered these tests to use `np.random.randint()` instead of `random.randint()` because the upper bounds when calling from NumPy are **not** inclusive.  This should take care of the `IndexError`s mentioned above, but if there are other flaky ones I can continue to adjust.


### Does this pull request make any user interface changes? If so please describe.

The user interface changes are...

No user interface changes. 


### What does your pull request address? Tag relevant issues.

This pull request addresses GH #532
