### PR TITLE
GitHub actions CI improvements

### DIFF
--- a/.github/actions/flepimop-install/action.yml
+++ b/.github/actions/flepimop-install/action.yml
@@ -1,0 +1,53 @@
+name: flepiMoP Install
+description: Install flepiMoP and its dependencies
+inputs:
+  python-version:
+    description: Python version to use
+    required: true
+    default: "3.11"
+  R-version:
+    description: R version to use
+    required: true
+    default: "4.3"
+runs:
+  using: "composite"
+  steps:
+    - name: Install system dependencies
+      run: |
+        sudo apt update
+        sudo apt install \
+          libcurl4-openssl-dev \
+          libharfbuzz-dev \
+          libfribidi-dev \
+          libtiff5-dev \
+          libudunits2-dev \
+          libgdal-dev \
+          libgeos-dev \
+          libproj-dev \
+          libfontconfig1-dev \
+          pandoc
+      shell: bash
+    - name: Setup miniconda
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        auto-update-conda: true
+    - name: Conda venv cache
+      id: conda-venv-cache
+      uses: actions/cache@v4
+      with:
+        key: flepimop-conda-${{ runner.os }}-${{ inputs.R-version }}-${{ inputs.python-version }}-${{ hashFiles('flepimop/R_packages/flepicommon/DESCRIPTION', 'flepimop/R_packages/flepicommon/NAMESPACE', 'flepimop/R_packages/flepiconfig/DESCRIPTION', 'flepimop/R_packages/flepiconfig/NAMESPACE', 'flepimop/R_packages/inference/DESCRIPTION', 'flepimop/R_packages/inference/NAMESPACE', 'flepimop/gempyor_pkg/pyproject.toml', 'environment.yml') }}
+        path: './venv'
+    - name: Install flepiMoP
+      if: steps.conda-venv-cache.outputs.cache-hit != 'true'
+      run: |
+        rm -rf venv/
+        sed -i 's/^- python.*$/- python=${{ inputs.python-version}}/g' environment.yml
+        sed -i 's/^- r-base.*$/- r-base=${{ inputs.R-version}}/g' environment.yml
+        ./bin/flepimop-install-dev
+      shell: bash -el {0}
+    - name: flepiMoP install info
+      run: |
+        conda activate venv/
+        export FLEPI_PATH=$(pwd)
+        ./bin/flepimop-install-info
+      shell: bash -el {0}

--- a/.github/workflows/conda-env.yml
+++ b/.github/workflows/conda-env.yml
@@ -2,12 +2,6 @@ name: Generate Conda Environment
 
 on:
   workflow_dispatch:
-  push:
-    paths:
-      - build/create_environment_yml.R
-      - flepimop/R_packages/*/DESCRIPTION
-    branches:
-      - dev
   pull_request:
     types:
       - edited

--- a/.github/workflows/flepicommon-ci.yml
+++ b/.github/workflows/flepicommon-ci.yml
@@ -26,9 +26,10 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     strategy:
       matrix:
-        R-version: ["4.3.3"]
+        python-version: ["3.11"]
+        R-version: ["4.3"]
     steps:
-      - name: Checkout
+      - name: Checkout flepiMoP
         uses: actions/checkout@v4
         with:
           lfs: true
@@ -36,56 +37,15 @@ jobs:
             *
             !documentation/
           sparse-checkout-cone-mode: false
-      - name: Setup R
-        uses: r-lib/actions/setup-r@v2
+          persist-credentials: false
+      - name: Install flepiMoP
+        uses: ./.github/actions/flepimop-install
         with:
-          r-version: ${{ matrix.R-version }}
-          update-rtools: true
-      - name: Install System Dependencies
-        run: sudo apt install libcurl4-openssl-dev libharfbuzz-dev libfribidi-dev libtiff5-dev libudunits2-dev libgdal-dev libgeos-dev libproj-dev libfontconfig1-dev
-      - name: Determine R Library Location
+          python-version: ${{ matrix.python-version }}
+          R-version: ${{ matrix.R-version }}
+      - name: Run tests
         run: |
-          R_LIBPATH=$( R -s -e "cat(.libPaths()[1L])" | xargs )
-          echo "R_LIBPATH=$R_LIBPATH" >> $GITHUB_ENV
-          R_LIBPATH_CKSUM=$( echo "$R_LIBPATH" | cksum | cut -d ' ' -f 1 )
-          echo "R_LIBPATH_CKSUM=$R_LIBPATH_CKSUM" >> $GITHUB_ENV
-          CACHE_DATE=$( date -d "last Sunday" +%Y%m%d )
-          echo "CACHE_DATE=$CACHE_DATE" >> $GITHUB_ENV
-      - name: R Library Cache
-        uses: actions/cache@v4
-        with:
-          key: flepicommon-rlibs-${{ runner.os }}-${{ matrix.R-version }}-${{ hashFiles('flepimop/R_packages/flepicommon/DESCRIPTION', 'flepimop/R_packages/flepicommon/NAMESPACE') }}-${{ env.R_LIBPATH_CKSUM }}-${{ env.CACHE_DATE }}
-          path: ${{ env.R_LIBPATH }}
-          restore-keys: |
-            flepicommon-rlibs-${{ runner.os }}-${{ matrix.R-version }}-${{ hashFiles('flepimop/R_packages/flepicommon/DESCRIPTION', 'flepimop/R_packages/flepicommon/NAMESPACE') }}-${{ env.R_LIBPATH_CKSUM }}-
-            flepicommon-rlibs-${{ runner.os }}-${{ matrix.R-version }}-${{ hashFiles('flepimop/R_packages/flepicommon/DESCRIPTION', 'flepimop/R_packages/flepicommon/NAMESPACE') }}-
-            flepicommon-rlibs-${{ runner.os }}-${{ matrix.R-version }}-
-      - name: Install R Dependencies
-        if: steps.r-library-cache.outputs.cache-hit != 'true'
-        run: |
-          install.packages(
-            "devtools",
-            repos = "https://cloud.r-project.org",
-          )
-          library(devtools)
-          devtools::install_deps(
-            pkg = "flepimop/R_packages/flepicommon",
-            dependencies = TRUE
-          )
-          install.packages("epidatr", repos = "https://cloud.r-project.org")
-        shell: Rscript {0}
-      - name: Install The flepicommon Package
-        run: |
-          devtools::install(
-            pkg = "flepimop/R_packages/flepicommon",
-            args = c(getOption("devtools.install.args"), "--install-tests"),
-            quick = TRUE,
-            dependencies = TRUE,
-            force = TRUE
-          )
-        shell: Rscript {0}
-      - name: Run Tests
-        run: |
-          library(testthat)
-          test_package("flepicommon")
-        shell: Rscript {0}
+          conda activate venv/
+          export FLEPI_PATH=$(pwd)
+          Rscript -e "library(testthat); test_package('flepicommon')"
+        shell: bash -el {0}

--- a/.github/workflows/flepicommon-ci.yml
+++ b/.github/workflows/flepicommon-ci.yml
@@ -2,11 +2,6 @@ name: flepicommon CI
 
 on:
   workflow_dispatch:
-  push:
-    paths:
-      - flepimop/R_packages/flepicommon/**/*
-    branches:
-      - dev
   pull_request:
     types:
       - edited

--- a/.github/workflows/gempyor-ci.yml
+++ b/.github/workflows/gempyor-ci.yml
@@ -29,8 +29,9 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.11"]
+        R-version: ["4.3"]
     steps:
-      - name: Checkout
+      - name: Checkout flepiMoP
         uses: actions/checkout@v4
         with:
           lfs: true
@@ -38,67 +39,69 @@ jobs:
             *
             !documentation/
           sparse-checkout-cone-mode: false
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+          persist-credentials: false
+      - name: Install flepiMoP
+        uses: ./.github/actions/flepimop-install
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install gempyor
+          R-version: ${{ matrix.R-version }}
+      - name: Run fast unit tests
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install "flepimop/gempyor_pkg[dev]"
-        shell: bash
-      - name: Run not slow tests
-        run: |
+          conda activate venv/
           export FLEPI_PATH=$(pwd)
           cd flepimop/gempyor_pkg
           pytest -m "not slow" --exitfirst
-        shell: bash
-      - name: Run slow tests
+        shell: bash -el {0}
+      - name: Run slow unit tests
         run: |
+          conda activate venv/
           export FLEPI_PATH=$(pwd)
           cd flepimop/gempyor_pkg
           pytest -m "slow" --exitfirst
-        shell: bash
+        shell: bash -el {0}
       - name: Run gempyor-cli integration tests from examples
         run: |
+          conda activate venv/
           cd examples
           pytest --exitfirst
-        shell: bash
+        shell: bash -el {0}
   doc-updates:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+        R-version: ["4.3"]
     steps:
-      - name: Checkout
+      - name: Checkout flepiMoP
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref || github.ref }}
           lfs: true
           sparse-checkout: |
             *
-            !tests/
+            !documentation/
           sparse-checkout-cone-mode: false
-      - name: Setup Python 3.11
-        uses: actions/setup-python@v5
+          persist-credentials: false
+      - name: Install flepiMoP
+        uses: ./.github/actions/flepimop-install
         with:
-          python-version: '3.11'
-      - name: Install gempyor
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install "flepimop/gempyor_pkg[dev]"
-        shell: bash
+          python-version: ${{ matrix.python-version }}
+          R-version: ${{ matrix.R-version }}
       - name: Build gempyor documentation with Sphinx
         run: |
+          conda activate venv/
+          export FLEPI_PATH=$(pwd)
           cd flepimop/gempyor_pkg/docs
           make fullbuild
-        shell: bash
-      - name: Install pandoc 
-        run: |
-          sudo apt-get update && sudo apt-get install -y pandoc
+        shell: bash -el {0}
       - name: Build click documentation with click-man
         run: |
+          conda activate venv/
+          export FLEPI_PATH=$(pwd)
           cd flepimop/gempyor_pkg
           click-man flepimop --target docs/cli_man --man-version 1
           python docs/click-man_parsing.py
+        shell: bash -el {0}
       - name: Remove temporal metadata from man page headers
         run: |
           sed -i 's/^\(\.TH [^"]* \)"[^"]*" "\(.*\)"/\1"" "\2"/' flepimop/gempyor_pkg/docs/cli_man/*.1

--- a/.github/workflows/gempyor-ci.yml
+++ b/.github/workflows/gempyor-ci.yml
@@ -2,12 +2,6 @@ name: gempyor CI
 
 on:
   workflow_dispatch:
-  push:
-    paths:
-      - examples/**/*
-      - flepimop/gempyor_pkg/**/*
-    branches:
-      - dev
   pull_request:
     types:
       - edited
@@ -23,7 +17,7 @@ on:
       - main
 
 jobs:
-  tests:
+  fast-tests:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     strategy:
@@ -59,18 +53,41 @@ jobs:
           cd flepimop/gempyor_pkg
           pytest -m "not slow" --exitfirst
         shell: bash -el {0}
-      - name: Run slow unit tests
-        run: |
-          conda activate venv/
-          export FLEPI_PATH=$(pwd)
-          cd flepimop/gempyor_pkg
-          pytest -m "slow" --exitfirst
-        shell: bash -el {0}
       - name: Run gempyor-cli integration tests from examples
         run: |
           conda activate venv/
           cd examples
           pytest --exitfirst
+        shell: bash -el {0}
+  slow-tests:
+    needs: fast-tests
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+        R-version: ["4.3"]
+    steps:
+      - name: Checkout flepiMoP
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+          sparse-checkout: |
+            *
+            !documentation/
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+      - name: Install flepiMoP
+        uses: ./.github/actions/flepimop-install
+        with:
+          python-version: ${{ matrix.python-version }}
+          R-version: ${{ matrix.R-version }}
+      - name: Run slow unit tests
+        run: |
+          conda activate venv/
+          export FLEPI_PATH=$(pwd)
+          cd flepimop/gempyor_pkg
+          pytest -m "slow"
         shell: bash -el {0}
   doc-updates:
     runs-on: ubuntu-latest

--- a/.github/workflows/gempyor-ci.yml
+++ b/.github/workflows/gempyor-ci.yml
@@ -45,6 +45,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           R-version: ${{ matrix.R-version }}
+      - name: Run doctests
+        run: |
+          conda activate venv/
+          export FLEPI_PATH=$(pwd)
+          cd flepimop/gempyor_pkg
+          pytest --doctest-modules --exitfirst src/gempyor/
+        shell: bash -el {0}
       - name: Run fast unit tests
         run: |
           conda activate venv/

--- a/.github/workflows/inference-ci.yml
+++ b/.github/workflows/inference-ci.yml
@@ -32,10 +32,10 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     strategy:
       matrix:
-        R-version: ["4.3.3"]
         python-version: ["3.10", "3.11"]
+        R-version: ["4.3"]
     steps:
-      - name: Checkout
+      - name: Checkout flepiMoP
         uses: actions/checkout@v4
         with:
           lfs: true
@@ -43,86 +43,15 @@ jobs:
             *
             !documentation/
           sparse-checkout-cone-mode: false
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+          persist-credentials: false
+      - name: Install flepiMoP
+        uses: ./.github/actions/flepimop-install
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install gempyor
+          R-version: ${{ matrix.R-version }}
+      - name: Run tests
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install "flepimop/gempyor_pkg[test]"
-        shell: bash
-      - name: Setup R
-        uses: r-lib/actions/setup-r@v2
-        with:
-          r-version: ${{ matrix.R-version }}
-          update-rtools: true
-      - name: Install System Dependencies
-        run: sudo apt install libcurl4-openssl-dev libharfbuzz-dev libfribidi-dev libtiff5-dev libudunits2-dev libgdal-dev libgeos-dev libproj-dev libfontconfig1-dev
-      - name: Determine R Library Location
-        run: |
-          R_LIBPATH=$( R -s -e "cat(.libPaths()[1L])" | xargs )
-          echo "R_LIBPATH=$R_LIBPATH" >> $GITHUB_ENV
-          R_LIBPATH_CKSUM=$( echo "$R_LIBPATH" | cksum | cut -d ' ' -f 1 )
-          echo "R_LIBPATH_CKSUM=$R_LIBPATH_CKSUM" >> $GITHUB_ENV
-          CACHE_DATE=$( date -d "last Sunday" +%Y%m%d )
-          echo "CACHE_DATE=$CACHE_DATE" >> $GITHUB_ENV
-      - name: R Library Cache
-        uses: actions/cache@v4
-        with:
-          key: inference-rlibs-${{ runner.os }}-${{ matrix.R-version }}-${{ hashFiles('flepimop/R_packages/flepicommon/DESCRIPTION', 'flepimop/R_packages/flepicommon/NAMESPACE', 'flepimop/R_packages/inference/DESCRIPTION', 'flepimop/R_packages/inference/NAMESPACE') }}-${{ env.R_LIBPATH_CKSUM }}-${{ env.CACHE_DATE }}
-          path: ${{ env.R_LIBPATH }}
-          restore-keys: |
-            inference-rlibs-${{ runner.os }}-${{ matrix.R-version }}-${{ hashFiles('flepimop/R_packages/flepicommon/DESCRIPTION', 'flepimop/R_packages/flepicommon/NAMESPACE', 'flepimop/R_packages/inference/DESCRIPTION', 'flepimop/R_packages/inference/NAMESPACE') }}-${{ env.R_LIBPATH_CKSUM }}-
-            inference-rlibs-${{ runner.os }}-${{ matrix.R-version }}-${{ hashFiles('flepimop/R_packages/flepicommon/DESCRIPTION', 'flepimop/R_packages/flepicommon/NAMESPACE', 'flepimop/R_packages/inference/DESCRIPTION', 'flepimop/R_packages/inference/NAMESPACE') }}-
-            inference-rlibs-${{ runner.os }}-${{ matrix.R-version }}-
-            flepicommon-rlibs-${{ runner.os }}-${{ matrix.R-version }}-${{ hashFiles('flepimop/R_packages/flepicommon/DESCRIPTION', 'flepimop/R_packages/flepicommon/NAMESPACE') }}-${{ env.R_LIBPATH_CKSUM }}-
-            flepicommon-rlibs-${{ runner.os }}-${{ matrix.R-version }}-${{ hashFiles('flepimop/R_packages/flepicommon/DESCRIPTION', 'flepimop/R_packages/flepicommon/NAMESPACE') }}-
-            flepicommon-rlibs-${{ runner.os }}-${{ matrix.R-version }}-
-      - name: Install R Dependencies For flepicommon
-        if: steps.r-library-cache.outputs.cache-hit != 'true'
-        run: |
-          install.packages(
-            "devtools",
-            repos = "https://cloud.r-project.org",
-          )
-          library(devtools)
-          devtools::install_deps(
-            pkg = "flepimop/R_packages/flepicommon",
-            dependencies = TRUE
-          )
-          install.packages("epidatr", repos = "https://cloud.r-project.org")
-        shell: Rscript {0}
-      - name: Install The flepicommon Package
-        run: |
-          devtools::install(
-            pkg = "flepimop/R_packages/flepicommon",
-            quick = TRUE,
-            dependencies = TRUE,
-            force = TRUE
-          )
-        shell: Rscript {0}
-      - name: Install R Dependencies For inference
-        if: steps.r-library-cache.outputs.cache-hit != 'true'
-        run: |
-          devtools::install_deps(
-            pkg = "flepimop/R_packages/inference",
-            dependencies = TRUE
-          )
-          install.packages("epidatr", repos = "https://cloud.r-project.org")
-        shell: Rscript {0}
-      - name: Install The inference Package
-        run: |
-          devtools::install(
-            pkg = "flepimop/R_packages/inference",
-            args = c(getOption("devtools.install.args"), "--install-tests"),
-            quick = TRUE,
-            dependencies = TRUE,
-            force = TRUE
-          )
-        shell: Rscript {0}
-      - name: Run Tests
-        run: |
-          library(testthat)
-          test_package("inference")
-        shell: Rscript {0}
+          conda activate venv/
+          export FLEPI_PATH=$(pwd)
+          Rscript -e "library(testthat); test_package('inference')"
+        shell: bash -el {0}

--- a/.github/workflows/inference-ci.yml
+++ b/.github/workflows/inference-ci.yml
@@ -2,14 +2,6 @@ name: inference CI
 
 on:
   workflow_dispatch:
-  push:
-    paths:
-      - flepimop/R_packages/inference/**/*
-      - flepimop/R_packages/flepicommon/**/*
-      - examples/**/*
-      - flepimop/gempyor_pkg/**/*
-    branches:
-      - dev
   pull_request:
     types:
       - edited

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -53,30 +53,35 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     env: 
       PYLINT_SRC: 'flepimop/gempyor_pkg/src/gempyor'
-      PYLINT_FAIL_UNDER: '4'
+      PYLINT_FAIL_UNDER: '5'
       PYLINT_RCFILE: 'flepimop/gempyor_pkg/.pylintrc'
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+        R-version: ["4.3"]
     steps:
-      - name: Checkout
+      - name: Checkout flepiMoP
         uses: actions/checkout@v4
         with:
           lfs: true
           sparse-checkout: |
-            flepimop/gempyor_pkg/
+            *
+            !documentation/
           sparse-checkout-cone-mode: false
-      - name: Setup Python
-        uses: actions/setup-python@v5
+          persist-credentials: false
+      - name: Install flepiMoP
+        uses: ./.github/actions/flepimop-install
         with:
-          python-version: '3.11'
-      - name: Install Pylint
+          python-version: ${{ matrix.python-version }}
+          R-version: ${{ matrix.R-version }}
+      - name: Run pylint
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install pylint
-      - name: Linting with Pylint
-        run: |
+          conda activate venv/
           pylint ${{ env.PYLINT_SRC }} \
             --fail-under ${{ env.PYLINT_FAIL_UNDER }} \
             --rcfile ${{ env.PYLINT_RCFILE }} \
             --verbose
+        shell: bash -el {0}
   check-info-json-schema:
     runs-on: ubuntu-latest
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false

--- a/bin/flepimop-install
+++ b/bin/flepimop-install
@@ -172,20 +172,7 @@ else
 fi
 
 # Install the local R packages
-CONDA_R_LIBS=$( realpath "$CONDA_PREFIX/lib/R/library" )
-R -e "install.packages('epidatr', '$CONDA_R_LIBS', repos='https://cloud.r-project.org')"
-RETURNTO=$( pwd )
-cd $FLEPI_PATH/flepimop/R_packages/
-R_PACKAGES=("flepicommon" "flepiconfig" "inference")
-for pkg in "${R_PACKAGES[@]}"; do
-    if [ -d "$pkg" ]; then
-        R_LIBS=$CONDA_R_LIBS R CMD INSTALL --install-tests $pkg
-    else
-        echo "WARNING: The R package '$pkg' does not exist in '$FLEPI_PATH/flepimop/R_packages/'. Skipping installation." >&2
-    fi
-done
-cd $RETURNTO
-R -e "library(inference); inference::install_cli()"
+FLEPI_PATH=$FLEPI_PATH CONDA_PREFIX=$CONDA_PREFIX $FLEPI_PATH/bin/flepimop-install-r-pkgs
 
 # Output a summary of the installation
 FLEPI_PATH=$FLEPI_PATH FLEPI_CONDA=$FLEPI_CONDA $FLEPI_PATH/bin/flepimop-install-info

--- a/bin/flepimop-install
+++ b/bin/flepimop-install
@@ -179,7 +179,7 @@ cd $FLEPI_PATH/flepimop/R_packages/
 R_PACKAGES=("flepicommon" "flepiconfig" "inference")
 for pkg in "${R_PACKAGES[@]}"; do
     if [ -d "$pkg" ]; then
-        R_LIBS=$CONDA_R_LIBS R CMD INSTALL $pkg
+        R_LIBS=$CONDA_R_LIBS R CMD INSTALL --install-tests $pkg
     else
         echo "WARNING: The R package '$pkg' does not exist in '$FLEPI_PATH/flepimop/R_packages/'. Skipping installation." >&2
     fi
@@ -188,27 +188,7 @@ cd $RETURNTO
 R -e "library(inference); inference::install_cli()"
 
 # Output a summary of the installation
-WHICH_R=$( which R )
-WHICH_PYTHON=$( which python )
-CONDA_VERSION=$( conda --version | cut -d' ' -f2 )
-R_VERSION=$( R --version | head -n 1 | cut -d' ' -f3 )
-PYTHON_VERSION=$( python --version | cut -d' ' -f2 )
-GEMPYOR_VERSION=$( pip show gempyor | grep Version | cut -d' ' -f2 )
-
-cat << EOF
-flepiMoP installation summary:
-> flepiMoP version: $( git -C $FLEPI_PATH rev-parse HEAD )
-> flepiMoP path: $FLEPI_PATH
-> flepiMoP conda env: $FLEPI_CONDA
-> conda: $CONDA_VERSION
-> R $R_VERSION: $WHICH_R
-> Python $PYTHON_VERSION: $WHICH_PYTHON
-> gempyor version: $GEMPYOR_VERSION
-EOF
-for pkg in "${R_PACKAGES[@]}"; do
-    PKG_VERSION=$( R -s -e "print(packageVersion('$pkg'))" | grep -oE "[0-9]+\.[0-9]+\.[0-9]+" )
-    echo "> R $pkg version: $PKG_VERSION"
-done
+FLEPI_PATH=$FLEPI_PATH FLEPI_CONDA=$FLEPI_CONDA $FLEPI_PATH/bin/flepimop-install-info
 cat << EOF
 To activate the flepimop conda environment, run:
     conda activate $FLEPI_CONDA

--- a/bin/flepimop-install-info
+++ b/bin/flepimop-install-info
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+WHICH_R=$( which R )
+WHICH_PYTHON=$( which python )
+CONDA_VERSION=$( conda --version | cut -d' ' -f2 )
+R_VERSION=$( R --version | head -n 1 | cut -d' ' -f3 )
+PYTHON_VERSION=$( python --version | cut -d' ' -f2 )
+GEMPYOR_VERSION=$( pip show gempyor | grep Version | cut -d' ' -f2 )
+R_PACKAGES=("flepicommon" "flepiconfig" "inference")
+
+echo "flepiMoP installation summary:"
+
+if command -v git &> /dev/null && [ -d "$FLEPI_PATH/.git" ]; then
+    FLEPI_VERSION=$( git -C "$FLEPI_PATH" rev-parse HEAD )
+    echo "> flepiMoP version: $FLEPI_VERSION"
+else
+    echo "> flepiMoP version: *could not determine version*"
+fi
+
+if test -n "$FLEPI_PATH"; then
+    echo "> flepiMoP path: $FLEPI_PATH"
+else
+    echo "> flepiMoP path: *not set*"
+fi
+
+if test -n "$FLEPI_CONDA"; then
+    echo "> flepiMoP conda env: $FLEPI_CONDA"
+else
+    echo "> flepiMoP conda env: *not set*"
+fi
+
+cat << EOF
+> conda: $CONDA_VERSION
+> R $R_VERSION: $WHICH_R
+> Python $PYTHON_VERSION: $WHICH_PYTHON
+> gempyor version: $GEMPYOR_VERSION
+EOF
+for pkg in "${R_PACKAGES[@]}"; do
+    PKG_VERSION=$( R -s -e "print(packageVersion('$pkg'))" | grep -oE "[0-9]+\.[0-9]+\.[0-9]+" )
+    echo "> R $pkg version: $PKG_VERSION"
+done

--- a/bin/flepimop-install-r-pkgs
+++ b/bin/flepimop-install-r-pkgs
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+if [[ -z "$FLEPI_PATH" ]]; then
+    FLEPI_PATH=$( pwd )
+fi
+CONDA_R_LIBS=$( realpath "$CONDA_PREFIX/lib/R/library" )
+R -e "install.packages('epidatr', '$CONDA_R_LIBS', repos='https://cloud.r-project.org')"
+RETURNTO=$( pwd )
+cd $FLEPI_PATH/flepimop/R_packages/
+R_PACKAGES=("flepicommon" "flepiconfig" "inference")
+for pkg in "${R_PACKAGES[@]}"; do
+    if [ -d "$pkg" ]; then
+        R_LIBS=$CONDA_R_LIBS R CMD INSTALL --install-tests $pkg
+    else
+        echo "WARNING: The R package '$pkg' does not exist in '$FLEPI_PATH/flepimop/R_packages/'. Skipping installation." >&2
+    fi
+done
+cd $RETURNTO
+R -e "library(inference); inference::install_cli()"

--- a/build/create_environment_yml.R
+++ b/build/create_environment_yml.R
@@ -32,19 +32,19 @@ dependencies <- dependencies[!grepl("^R(\\(.*\\))?$", dependencies)]
 environment_yml <- file.path(flepi_path, "environment.yml")
 new_environment_yml <- c(
   "channels:",
-  "- conda-forge",
-  "- defaults",
-  "- r",
-  "- dnachun",
+  "  - conda-forge",
+  "  - defaults",
+  "  - r",
+  "  - dnachun",
   "dependencies:",
-  "- python=3.11",
-  "- pip",
-  "- r-base>=4.3",
-  "- pyarrow=17.0.0",
-  "- r-arrow=17.0.0",
-  "- r-sf",
-  "- r-testthat",
-  paste0("- r-", dependencies)
+  "  - python=3.11",
+  "  - pip",
+  "  - r-base>=4.3",
+  "  - pyarrow=17.0.0",
+  "  - r-arrow=17.0.0",
+  "  - r-sf",
+  "  - r-testthat",
+  paste0("  - r-", dependencies)
 )
 if (file.exists(environment_yml)) {
   old_environment_yml <- readLines(environment_yml)

--- a/build/create_environment_yml.R
+++ b/build/create_environment_yml.R
@@ -43,6 +43,7 @@ new_environment_yml <- c(
   "- pyarrow=17.0.0",
   "- r-arrow=17.0.0",
   "- r-sf",
+  "- r-testthat",
   paste0("- r-", dependencies)
 )
 if (file.exists(environment_yml)) {

--- a/documentation/gitbook/development/python-guidelines-for-developers.md
+++ b/documentation/gitbook/development/python-guidelines-for-developers.md
@@ -34,31 +34,31 @@ One of the current focus is to switch internal data types from dataframes and nu
 To run the tests suite locally, you'll need to install the gempyor package with build dependencies:
 
 ```bash
-pip install "flepimop/gempyor_pkg[test]"
+pip install "flepimop/gempyor_pkg[dev]"
 ```
 
-which installs the `pytest` and `mock` packages in addition to all other gempyor dependencies so that one can run tests.
-
-If you are running from a conda environment and installing with \`--no-deps\`, then you should make sure that these two packages are installed.
-
-Now you can try to run the gempyor test suite by running, from the `flepimop/gempyor_pkg` folder:
+which installs the `pytest` package in addition to all other gempyor dependencies so that one can run tests. Now you can try to run the gempyor test suite by running, from the `flepimop/gempyor_pkg` folder:
 
 ```bash
 pytest
 ```
 
-If that works, then you are ready to develop gempyor. Feel free to open your first pull request.
-
-If you want more output on tests, e.g capturing standard output (print), you can use:
+If that works, then you are ready to develop gempyor. Feel free to open your first pull request. If you want more output on tests, e.g capturing standard output (print), you can use:
 
 ```bash
-pytest -vvvv
+pytest -vvv
 ```
 
-and to run just some subset of the tests (e.g here just the outcome tests), use:
+And to run just some subset of the tests (e.g here just the outcome tests), use:
 
 ```bash
-pytest -vvvv -k outcomes
+pytest -vvv -k outcomes
+```
+
+Furthermore, to ensure that the examples provided in the documentation are high quality we run the doctests in CI with:
+
+```bash
+pytest --doctest-modules src/gempyor/
 ```
 
 For more details on how to use `pytest` please refer to their [usage guide](https://docs.pytest.org/en/latest/how-to/usage.html).

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-# Mon Jun 16 21:15:32 2025 UTC
+# Thu Jul 17 19:26:17 2025 UTC
 channels:
 - conda-forge
 - defaults
@@ -11,6 +11,7 @@ dependencies:
 - pyarrow=17.0.0
 - r-arrow=17.0.0
 - r-sf
+- r-testthat
 - r-data.table
 - r-doParallel
 - r-dplyr

--- a/environment.yml
+++ b/environment.yml
@@ -1,40 +1,40 @@
-# Thu Jul 17 19:26:17 2025 UTC
+# Tue Jul 22 20:21:27 2025 UTC
 channels:
-- conda-forge
-- defaults
-- r
-- dnachun
+  - conda-forge
+  - defaults
+  - r
+  - dnachun
 dependencies:
-- python=3.11
-- pip
-- r-base>=4.3
-- pyarrow=17.0.0
-- r-arrow=17.0.0
-- r-sf
-- r-testthat
-- r-data.table
-- r-doParallel
-- r-dplyr
-- r-foreach
-- r-ggplot2
-- r-ggraph
-- r-httr
-- r-jsonlite
-- r-lubridate
-- r-magrittr
-- r-MMWRweek
-- r-optparse
-- r-purrr
-- r-readr
-- r-reticulate
-- r-rlang
-- r-stringr
-- r-tibble
-- r-tidygraph
-- r-tidyr
-- r-tidyselect
-- r-tidyverse
-- r-truncnorm
-- r-vroom
-- r-xts
-- r-yaml
+  - python=3.11
+  - pip
+  - r-base>=4.3
+  - pyarrow=17.0.0
+  - r-arrow=17.0.0
+  - r-sf
+  - r-testthat
+  - r-data.table
+  - r-doParallel
+  - r-dplyr
+  - r-foreach
+  - r-ggplot2
+  - r-ggraph
+  - r-httr
+  - r-jsonlite
+  - r-lubridate
+  - r-magrittr
+  - r-MMWRweek
+  - r-optparse
+  - r-purrr
+  - r-readr
+  - r-reticulate
+  - r-rlang
+  - r-stringr
+  - r-tibble
+  - r-tidygraph
+  - r-tidyr
+  - r-tidyselect
+  - r-tidyverse
+  - r-truncnorm
+  - r-vroom
+  - r-xts
+  - r-yaml

--- a/flepimop/gempyor_pkg/conftest.py
+++ b/flepimop/gempyor_pkg/conftest.py
@@ -1,0 +1,18 @@
+"""Pytest configuration file."""
+
+from collections.abc import Generator
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _docdir(request: pytest.FixtureRequest) -> Generator[None, None, None]:
+    # Run doctests in the temporary directory.
+    # https://stackoverflow.com/q/46962007
+    doctest_plugin = request.config.pluginmanager.getplugin("doctest")
+    if isinstance(request.node, doctest_plugin.DoctestItem):
+        tmpdir = request.getfixturevalue("tmpdir")
+        with tmpdir.as_cwd():
+            yield
+    else:
+        yield

--- a/flepimop/gempyor_pkg/src/gempyor/_jinja.py
+++ b/flepimop/gempyor_pkg/src/gempyor/_jinja.py
@@ -77,7 +77,7 @@ def _render_template_to_temp_file(
         ...     "test_template.j2", {"name": "John"}, suffix=".txt", prefix="foo_"
         ... )
         >>> file
-        PosixPath('/var/folders/2z/h3pc0p7s3ng1tvxrgsw5kr680000gp/T/foo_ocaomg4k.txt')
+        PosixPath(...)
         >>> file.read_text()
         'Hello John!'
     """

--- a/flepimop/gempyor_pkg/src/gempyor/_pydantic_ext.py
+++ b/flepimop/gempyor_pkg/src/gempyor/_pydantic_ext.py
@@ -134,16 +134,20 @@ def _read_and_validate_dataframe(
         ...     name: str
         ...     age: int
         >>> _read_and_validate_dataframe(file, model=Person)
-        name  age
+           name  age
         0  Jack   23
         1  Jill   25
         >>> pd.DataFrame(data={"name": [32], "age": ["Jane"]}).to_csv(file, index=False)
         >>> _read_and_validate_dataframe(file, model=Person)
         Traceback (most recent call last):
             ...
-        pydantic_core._pydantic_core.ValidationError: 1 validation error for RootModel[list[Person]]
+        pydantic_core._pydantic_core.ValidationError: 2 validation errors for RootModel[list[Person]]
+        0.name
+          Input should be a valid string [type=string_type, input_value=32, input_type=int]
+            For further information visit https://errors.pydantic.dev/2.11/v/string_type
         0.age
-        Input should be a valid integer, unable to parse string as an integer ...
+          Input should be a valid integer, unable to parse string as an integer [type=int_parsing, input_value='Jane', input_type=str]
+            For further information visit https://errors.pydantic.dev/2.11/v/int_parsing
         >>> class PartitionSlice(BaseModel):
         ...     name: str
         ...     amount: Annotated[float, Field(gt=0.0, lt=1.0)]
@@ -159,7 +163,7 @@ def _read_and_validate_dataframe(
         ...     data={"name": ["A", "B"], "amount": [0.5, 0.5]},
         ... ).to_csv(file, index=False)
         >>> _read_and_validate_dataframe(file, model=Partition)
-        name  amount
+          name  amount
         0    A     0.5
         1    B     0.5
         >>> pd.DataFrame(
@@ -169,7 +173,8 @@ def _read_and_validate_dataframe(
         Traceback (most recent call last):
             ...
         pydantic_core._pydantic_core.ValidationError: 1 validation error for Partition
-        Value error, The sum of the amounts must be equal to 1.0 ...
+          Value error, The sum of the amounts must be equal to 1.0 [type=value_error, input_value=[{'name': 'A', 'amount': ...e': 'B', 'amount': 0.1}], input_type=list]
+            For further information visit https://errors.pydantic.dev/2.11/v/value_error
 
     """
     if file.suffix == ".csv":
@@ -213,8 +218,8 @@ def _evaled_expression(val: EE | str | Any, target_type: Type[EE]) -> EE | Any:
         2
         >>> _evaled_expression("10 / 4", float)
         2.5
+        >>> # Note that result is truncated, probably undesirable if misused
         >>> _evaled_expression("10 / 4", int)
-        # note that result is trucnated; probably undesirable if misused
         2
         >>> _evaled_expression(99.5, float)
         99.5
@@ -223,7 +228,7 @@ def _evaled_expression(val: EE | str | Any, target_type: Type[EE]) -> EE | Any:
         >>> _evaled_expression("a * b", float)
         Traceback (most recent call last):
             ...
-        ValueError: Can't convert expression to float.
+        ValueError: Cannot convert expression 'a*b' to <class 'float'>.
     """
     if isinstance(val, target_type):
         return val

--- a/flepimop/gempyor_pkg/src/gempyor/batch/_helpers.py
+++ b/flepimop/gempyor_pkg/src/gempyor/batch/_helpers.py
@@ -39,12 +39,8 @@ def _job_name(name: str | None, timestamp: datetime | None) -> str:
         ValueError: If `name` does not start with a letter and contains characters other
             than the alphabet, numbers, underscores or dashes.
     Examples:
-        >>> from gempyor.batch import _job_name
-        >>> _job_name(None, None)
-        '20241105T153818'
-        >>> _job_name("foobar", None)
-        'foobar-20241105T153831'
         >>> from datetime import datetime, timezone
+        >>> from gempyor.batch._helpers import _job_name
         >>> _job_name(None, datetime(2024, 1, 1, tzinfo=timezone.utc))
         '20240101T000000'
     """
@@ -66,7 +62,7 @@ def _parse_extra_options(extra: Iterable[str] | None) -> dict[str, str]:
         A dictionary of the parsed extra options.
 
     Examples:
-        >>> from gempyor.batch import _parse_extra_options
+        >>> from gempyor.batch._helpers import _parse_extra_options
         >>> _parse_extra_options(["abc=def", "ghi=jkl"])
         {'abc': 'def', 'ghi': 'jkl'}
         >>> _parse_extra_options([

--- a/flepimop/gempyor_pkg/src/gempyor/batch/manifest.py
+++ b/flepimop/gempyor_pkg/src/gempyor/batch/manifest.py
@@ -42,22 +42,6 @@ def write_manifest(
 
     Returns:
         The path to the written json file.
-
-    Examples:
-        >>> import os
-        >>> from pathlib import Path
-        >>> flepi_path = Path(os.environ["FLEPI_PATH"])
-        >>> project_path = flepi_path / "examples" / "tutorials"
-        >>> manifest = write_manifest("Foobar", flepi_path, project_path)
-        >>> manifest.name
-        'manifest.json'
-        >>> print(manifest.read_text())
-        {
-            "cmd": "",
-            "job_name": "Foobar",
-            "data_sha": "59fe36d13fe34b6c1fb5c92bf8c53b83bd3ba593",
-            "flepimop_sha": "2bdfbc74e69bdd0243ef8340dda238f5504f1ad9"
-        }
     """
     flepimop_sha = _git_head(flepi_path)
     data_sha = _git_head(project_path)

--- a/flepimop/gempyor_pkg/src/gempyor/batch/systems.py
+++ b/flepimop/gempyor_pkg/src/gempyor/batch/systems.py
@@ -67,7 +67,7 @@ class BatchSystem(ABC):
         >>> batch_system.format_time_limit(time_limit)
         '1595'
         >>> batch_system.size_from_jobs_simulations_blocks(2, 10, None, 5)
-        JobSize(blocks=2, chains=10, samples=None, simulations=5)
+        JobSize(blocks=2, chains=10, samples=None, simulations=5, samples_per_chain=None, simulations_per_chain=10, total_samples=None, total_simulations=100)
     """
 
     needs_cluster: bool = False
@@ -300,7 +300,7 @@ class LocalBatchSystem(BatchSystem):
         >>> from gempyor.batch import LocalBatchSystem
         >>> batch_system = LocalBatchSystem()
         >>> batch_system.size_from_jobs_simulations_blocks(1, 1, 25, 50)
-        JobSize(blocks=1, chains=1, samples=25, simulations=50)
+        JobSize(blocks=1, chains=1, samples=25, simulations=50, samples_per_chain=25, simulations_per_chain=50, total_samples=25, total_simulations=50)
         >>> with warnings.catch_warnings(record=True) as warns:
         ...     size = batch_system.size_from_jobs_simulations_blocks(2, 4, 50, 100)
         ...     for warn in warns:
@@ -308,10 +308,10 @@ class LocalBatchSystem(BatchSystem):
         ...
         Local batch system only supports 1 chain but was given 4, overriding.
         Local batch system only supports 1 block but was given 2, overriding.
-        Local batch system only supports 50 total simulations but was given 800, overriding.
         Local batch system only supports 25 total samples but was given 400, overriding.
+        Local batch system only supports 50 total simulations but was given 800, overriding.
         >>> size
-        JobSize(blocks=1, chains=1, samples=25, simulations=50)
+        JobSize(blocks=1, chains=1, samples=25, simulations=50, samples_per_chain=25, simulations_per_chain=50, total_samples=25, total_simulations=50)
     """
 
     name = "local"
@@ -625,19 +625,6 @@ def register_batch_system(batch_system: BatchSystem) -> None:
     Raises:
         ValueError: If the batch system is already registered, checks the `name`
             attribute to determine this.
-
-    Examples:
-        >>> from gempyor.batch import BatchSystem, register_batch_system
-        >>> class CustomBatchSystem(BatchSystem):
-        ...     name = "custom"
-        >>> register_batch_system(CustomBatchSystem()) is None
-        True
-        >>> try:
-        ...     register_batch_system(CustomBatchSystem()) is None
-        ... except Exception as e:
-        ...     print(e)
-        ...
-        Batch system 'custom' already registered.
     """
     if any(batch_system.name == bs.name for bs in _batch_systems):
         raise ValueError(f"Batch system '{batch_system.name}' already registered.")
@@ -665,9 +652,9 @@ def get_batch_system(name: str, raise_on_missing: bool = True) -> BatchSystem | 
     Examples:
         >>> from gempyor.batch import get_batch_system
         >>> get_batch_system("local")
-        <gempyor.batch.LocalBatchSystem object at 0x1629f9b10>
+        <gempyor.batch.systems.LocalBatchSystem object at ...>
         >>> get_batch_system("slurm")
-        <gempyor.batch.SlurmBatchSystem object at 0x1629f9ad0>
+        <gempyor.batch.systems.SlurmBatchSystem object at ...>
         >>> try:
         ...     get_batch_system("does not exist")
         ... except Exception as e:
@@ -715,7 +702,7 @@ def _resolve_batch_system_name(name: str | None, local: bool, slurm: bool) -> st
         ValueError: If the given name conflicts with the boolean flags.
 
     Examples:
-        >>> from gempyor.batch import _resolve_batch_system_name
+        >>> from gempyor.batch.systems import _resolve_batch_system_name
         >>> _resolve_batch_system_name("abc", False, False)
         'abc'
         >>> _resolve_batch_system_name("SLURM", False, False)

--- a/flepimop/gempyor_pkg/src/gempyor/batch/types.py
+++ b/flepimop/gempyor_pkg/src/gempyor/batch/types.py
@@ -71,22 +71,20 @@ class JobResources(BaseModel):
         51200
         >>> resources.total_resources()
         (5, 50, 51200)
-        >>> try:
-        ...     JobResources(nodes=0, cpus=1, memory=1024)
-        ... except Exception as e:
-        ...     print(e)
-        1 validation error for JobResources
+        >>> JobResources(nodes=0, cpus=1, memory=1024)
+        Traceback (most recent call last):
+            ...
+        pydantic_core._pydantic_core.ValidationError: 1 validation error for JobResources
         nodes
-        Input should be greater than 0 [type=greater_than, input_value=0, input_type=int]
-            For further information visit https://errors.pydantic.dev/2.10/v/greater_than
-        >>> try:
-        ...     JobResources(nodes=2, cpus=4.5, memory=1024)
-        ... except Exception as e:
-        ...     print(e)
-        1 validation error for JobResources
+          Input should be greater than 0 [type=greater_than, input_value=0, input_type=int]
+            For further information visit https://errors.pydantic.dev/2.11/v/greater_than
+        >>> JobResources(nodes=2, cpus=4.5, memory=1024)
+        Traceback (most recent call last):
+            ...
+        pydantic_core._pydantic_core.ValidationError: 1 validation error for JobResources
         cpus
-        Input should be a valid integer, got a number with a fractional part [type=int_from_float, input_value=4.5, input_type=float]
-            For further information visit https://errors.pydantic.dev/2.10/v/int_from_float
+          Input should be a valid integer, got a number with a fractional part [type=int_from_float, input_value=4.5, input_type=float]
+            For further information visit https://errors.pydantic.dev/2.11/v/int_from_float
     """
 
     nodes: PositiveInt
@@ -190,44 +188,37 @@ class JobSize(BaseModel):
         >>> import warnings
         >>> from gempyor.batch import JobSize
         >>> JobSize(blocks=5, chains=10, samples=100, simulations=200)
-        JobSize(blocks=5, chains=10, samples=100, simulations=200)
+        JobSize(blocks=5, chains=10, samples=100, simulations=200, samples_per_chain=500, simulations_per_chain=1000, total_samples=5000, total_simulations=10000)
         >>> JobSize(chains=32, simulations=500)
-        JobSize(blocks=None, chains=32, samples=None, simulations=500)
-        >>> try:
-        ...     JobSize(blocks=0, chains=12, simulations=100)
-        ... except Exception as e:
-        ...     print(e)
-        ...
-        1 validation error for JobSize
+        JobSize(blocks=None, chains=32, samples=None, simulations=500, samples_per_chain=None, simulations_per_chain=500, total_samples=None, total_simulations=16000)
+        >>> JobSize(blocks=0, chains=12, simulations=100)
+        Traceback (most recent call last):
+            ...
+        pydantic_core._pydantic_core.ValidationError: 1 validation error for JobSize
         blocks
-        Input should be greater than 0 [type=greater_than, input_value=0, input_type=int]
-            For further information visit https://errors.pydantic.dev/2.10/v/greater_than
-        >>> try:
-        ...     JobSize(chains=10, samples=50.5, simulations=200)
-        ... except Exception as e:
-        ...     print(e)
-        ...
-        1 validation error for JobSize
+          Input should be greater than 0 [type=greater_than, input_value=0, input_type=int]
+            For further information visit https://errors.pydantic.dev/2.11/v/greater_than
+        >>> JobSize(chains=10, samples=50.5, simulations=200)
+        Traceback (most recent call last):
+            ...
+        pydantic_core._pydantic_core.ValidationError: 1 validation error for JobSize
         samples
-        Input should be a valid integer, got a number with a fractional part [type=int_from_float, input_value=50.5, input_type=float]
-            For further information visit https://errors.pydantic.dev/2.10/v/int_from_float
-        >>> try:
-        ...     JobSize(samples=100, simulations=50)
-        ... except Exception as e:
-        ...     print(e)
-        ...
-        1 validation error for JobSize
-        Value error, The number of samples, 100, must be less than or equal to the number of simulations, 50, per a block. [type=value_error, input_value={'samples': 100, 'simulations': 50}, input_type=dict]
-            For further information visit https://errors.pydantic.dev/2.10/v/value_error
+          Input should be a valid integer, got a number with a fractional part [type=int_from_float, input_value=50.5, input_type=float]
+            For further information visit https://errors.pydantic.dev/2.11/v/int_from_float
+        >>> JobSize(samples=100, simulations=50)
+        Traceback (most recent call last):
+            ...
+        pydantic_core._pydantic_core.ValidationError: 1 validation error for JobSize
+          Value error, The number of samples, 100, must be less than or equal to the number of simulations, 50, per a block. [type=value_error, input_value={'samples': 100, 'simulations': 50}, input_type=dict]
+            For further information visit https://errors.pydantic.dev/2.11/v/value_error
         >>> with warnings.catch_warnings(record=True) as warns:
         ...     JobSize(samples=75, simulations=100)
         ...     for warn in warns:
         ...             print(warn.message)
-        ...
-        JobSize(blocks=None, chains=None, samples=75, simulations=100)
+        JobSize(blocks=None, chains=None, samples=75, simulations=100, samples_per_chain=75, simulations_per_chain=100, total_samples=75, total_simulations=100)
         The samples to simulations ratio is 75%, which is higher than the recommended limit of 60%.
         >>> JobSize()
-        JobSize(blocks=None, chains=None, samples=None, simulations=None)
+        JobSize(blocks=None, chains=None, samples=None, simulations=None, samples_per_chain=None, simulations_per_chain=None, total_samples=None, total_simulations=None)
         >>> size = JobSize(blocks=4, chains=3, samples=10, simulations=25)
         >>> size.samples_per_chain
         40

--- a/flepimop/gempyor_pkg/src/gempyor/config_validator.py
+++ b/flepimop/gempyor_pkg/src/gempyor/config_validator.py
@@ -6,6 +6,7 @@ from pydantic import (
     Field,
     AfterValidator,
     validator,
+    field_validator,
 )
 from datetime import date
 from typing import Dict, List, Union, Literal, Optional, Annotated, Any

--- a/flepimop/gempyor_pkg/src/gempyor/distributions.py
+++ b/flepimop/gempyor_pkg/src/gempyor/distributions.py
@@ -108,7 +108,7 @@ class NormalDistribution(DistributionABC):
         >>> rng = np.random.default_rng(42)
         >>> dist = NormalDistribution(mu=2.3, sigma=4.5)
         >>> dist
-        NormalDistribution(distribution='norm', mu=2.3, sigma=4.5)
+        NormalDistribution(distribution='norm', allow_edge_cases=False, mu=2.3, sigma=4.5)
         >>> dist.sample(rng=rng)
         array([3.67122686])
         >>> dist.sample(size=(3, 5), rng=rng)
@@ -138,7 +138,7 @@ class UniformDistribution(DistributionABC):
         >>> rng = np.random.default_rng(42)
         >>> dist = UniformDistribution(low=-0.5, high=1.5)
         >>> dist
-        UniformDistribution(distribution='uniform', low=-0.5, high=1.5)
+        UniformDistribution(distribution='uniform', allow_edge_cases=False, low=-0.5, high=1.5)
         >>> dist.sample(rng=rng)
         array([1.0479121])
         >>> dist.sample(size=(3, 5), rng=rng)
@@ -190,7 +190,7 @@ class LognormalDistribution(DistributionABC):
         >>> rng = np.random.default_rng(42)
         >>> dist = LognormalDistribution(meanlog=0.0, sdlog=1.0)
         >>> dist
-        LognormalDistribution(distribution='lognorm', meanlog=0.0, sdlog=1.0)
+        LognormalDistribution(distribution='lognorm', allow_edge_cases=False, meanlog=0.0, sdlog=1.0)
         >>> dist.sample(rng=rng)
         array([1.35624124])
         >>> dist.sample(size=(3, 5), rng=rng)
@@ -221,7 +221,7 @@ class TruncatedNormalDistribution(DistributionABC):
         >>> rng = np.random.default_rng(42)
         >>> dist = TruncatedNormalDistribution(mean=1.0, sd=1.0, a=0.0, b=10.0)
         >>> dist
-        TruncatedNormalDistribution(distribution='truncnorm', mean=1.0, sd=1.0, a=0.0, b=10.0)
+        TruncatedNormalDistribution(distribution='truncnorm', allow_edge_cases=False, mean=1.0, sd=1.0, a=0.0, b=10.0)
         >>> dist.sample(rng=rng)
         array([1.87722989])
         >>> dist.sample(size=(3, 5), rng=rng)
@@ -288,7 +288,7 @@ class PoissonDistribution(DistributionABC):
         >>> rng = np.random.default_rng(42)
         >>> dist = PoissonDistribution(lam=3.0)
         >>> dist
-        PoissonDistribution(distribution='poisson', lam=3.0)
+        PoissonDistribution(distribution='poisson', allow_edge_cases=False, lam=3.0)
         >>> dist.sample(rng=rng)
         array([4])
         >>> dist.sample(size=(3, 5), rng=rng)
@@ -335,7 +335,7 @@ class BinomialDistribution(DistributionABC):
         >>> rng = np.random.default_rng(42)
         >>> dist = BinomialDistribution(n=10, p=0.5)
         >>> dist
-        BinomialDistribution(distribution='binomial', n=10, p=0.5)
+        BinomialDistribution(distribution='binomial', allow_edge_cases=False, n=10, p=0.5)
         >>> dist.sample(rng=rng)
         array([6])
         >>> dist.sample(size=(3, 5), rng=rng)
@@ -351,7 +351,8 @@ class BinomialDistribution(DistributionABC):
         Traceback (most recent call last):
             ...
         pydantic_core._pydantic_core.ValidationError: 1 validation error for BinomialDistribution
-          Value error, `p` cannot be 0 or 1 when `allow_edge_cases` is `False`. [type=value_error, ...
+          Value error, Input for `p` cannot be 0 or 1 when `allow_edge_cases` is `False`. [type=value_error, input_value={'n': 10, 'p': 0.0}, input_type=dict]
+            For further information visit https://errors.pydantic.dev/2.11/v/value_error
     """
 
     distribution: Literal["binomial"] = "binomial"
@@ -389,13 +390,13 @@ class GammaDistribution(DistributionABC):
         >>> rng = np.random.default_rng(42)
         >>> dist = GammaDistribution(shape=2.0, scale=1.5)
         >>> dist
-        GammaDistribution(distribution='gamma', shape=2.0, scale=1.5)
+        GammaDistribution(distribution='gamma', allow_edge_cases=False, shape=2.0, scale=1.5)
         >>> dist.sample(rng=rng)
-        array([2.78453141])
+        array([3.13772591])
         >>> dist.sample(size=(3, 5), rng=rng)
-        array([[1.0116844 , 5.1632733 , 6.51682397, 0.49053229, 0.82522731],
-               [2.45524838, 1.4870423 , 1.95460596, 0.94191942, 5.92679803],
-               [5.08819234, 2.21976694, 7.82570081, 3.42761858, 1.1070266 ]])
+        array([[4.25301838, 2.75582337, 2.46760563, 4.61888299, 2.63006031],
+               [3.51900762, 3.28422915, 4.61612039, 2.15883076, 5.69337578],
+               [1.75889742, 3.67897959, 3.38745296, 1.6334585 , 3.89261212]])
     """
 
     distribution: Literal["gamma"] = "gamma"
@@ -419,13 +420,13 @@ class WeibullDistribution(DistributionABC):
         >>> rng = np.random.default_rng(42)
         >>> dist = WeibullDistribution(shape=2.5, scale=5.0)
         >>> dist
-        WeibullDistribution(distribution='weibull', shape=2.5, scale=5.0)
+        WeibullDistribution(distribution='weibull', allow_edge_cases=False, shape=2.5, scale=5.0)
         >>> dist.sample(rng=rng)
-        array([5.18664161])
+        array([7.10164344])
         >>> dist.sample(size=(3, 5), rng=rng)
-        array([[4.09267151, 6.25764353, 6.57560416, 2.72348545, 3.73147743],
-               [5.08637841, 4.63044996, 4.96639599, 3.99658252, 6.42564251],
-               [6.29525049, 5.03450379, 6.88371131, 5.65602432, 3.99307222]])
+        array([[7.02058405, 7.0786094 , 3.00403884, 1.87780582, 5.8054469 ],
+               [5.73657673, 7.886256  , 1.81412232, 5.0918523 , 1.73016943],
+               [5.17350562, 6.22761392, 3.4198509 , 5.43445321, 2.36440749]])
     """
 
     distribution: Literal["weibull"] = "weibull"
@@ -450,13 +451,13 @@ class BetaDistribution(DistributionABC):
         >>> rng = np.random.default_rng(42)
         >>> dist = BetaDistribution(alpha=2.0, beta=5.0)
         >>> dist
-        BetaDistribution(distribution='beta', alpha=2.0, beta=5.0)
+        BetaDistribution(distribution='beta', allow_edge_cases=False, alpha=2.0, beta=5.0)
         >>> dist.sample(rng=rng)
-        array([0.31153835])
+        array([0.24395464])
         >>> dist.sample(size=(3, 5), rng=rng)
-        array([[0.18343469, 0.43545995, 0.48512838, 0.08625927, 0.22223849],
-               [0.34020943, 0.28014294, 0.3069152 , 0.201726  , 0.4729195 ],
-               [0.44331908, 0.32357912, 0.5282496 , 0.38318282, 0.20141687]])
+        array([[0.28406092, 0.39027204, 0.29864681, 0.41835336, 0.49963165],
+               [0.30396328, 0.15089427, 0.32937986, 0.52373987, 0.16127411],
+               [0.32746504, 0.48761242, 0.2162056 , 0.29178583, 0.22819733]])
     """
 
     distribution: Literal["beta"] = "beta"

--- a/flepimop/gempyor_pkg/src/gempyor/file_paths.py
+++ b/flepimop/gempyor_pkg/src/gempyor/file_paths.py
@@ -55,7 +55,7 @@ def create_file_name(
         ...     "jkl",
         ...     create_directory=False,
         ... )
-        PosixPath('model_output/abc/hosp/global/jkl000000001.20240101_000000.hosp.parquet')
+        'model_output/abc/hosp/global/jkl000000001.20240101_000000.hosp.parquet'
     """
     if create_directory:
         os.makedirs(
@@ -157,8 +157,6 @@ def run_id(timestamp: None | datetime = None) -> str:
     Examples:
         >>> from datetime import datetime, timezone
         >>> from gempyor.file_paths import run_id
-        >>> run_id()
-        '20240711_160059'
         >>> run_id(timestamp=datetime(2024, 1, 1))
         '20240101_000000'
         >>> run_id(timestamp=datetime(2024, 1, 1, tzinfo=timezone.utc))

--- a/flepimop/gempyor_pkg/src/gempyor/info.py
+++ b/flepimop/gempyor_pkg/src/gempyor/info.py
@@ -30,6 +30,10 @@ Notes:
     function being used via the `search_paths` argument.
 
 Examples:
+    >>> import os
+    >>> import pytest
+    >>> if "FLEPI_PATH" not in os.environ:
+    ...     pytest.skip("FLEPI_PATH environment variable is not set.")
     >>> from pprint import pprint
     >>> from gempyor.info import get_cluster_info
     >>> cluster_info = get_cluster_info("longleaf")
@@ -37,9 +41,9 @@ Examples:
     'longleaf'
     >>> pprint(cluster_info.modules)
     [Module(name='gcc', version='9.1.0'),
-    Module(name='anaconda', version='2023.03'),
-    Module(name='git', version=None),
-    Module(name='aws', version=None)]
+     Module(name='anaconda', version='2023.03'),
+     Module(name='git', version=None),
+     Module(name='aws', version=None)]
 """
 
 __all__ = ["Cluster", "Module", "PathExport", "get_cluster_info"]
@@ -188,6 +192,10 @@ def get_cluster_info(
         An object containing the information about the `name` cluster.
 
     Examples:
+        >>> import os
+        >>> import pytest
+        >>> if "FLEPI_PATH" not in os.environ:
+        ...     pytest.skip("FLEPI_PATH environment variable is not set.")
         >>> from gempyor.info import get_cluster_info
         >>> cluster_info = get_cluster_info("longleaf")
         >>> cluster_info.name

--- a/flepimop/gempyor_pkg/src/gempyor/logging.py
+++ b/flepimop/gempyor_pkg/src/gempyor/logging.py
@@ -106,7 +106,7 @@ def get_script_logger(
     Examples:
         >>> from gempyor.logging import get_script_logger
         >>> logger = get_script_logger(__name__, 3)
-        >>> logger.info("This is a log info message")
+        >>> logger.info("This is a log info message")  # doctest: +SKIP
         2024-10-29 16:07:20,272:INFO:__main__> This is a log info message.
     """
     logger = logging.getLogger(name)

--- a/flepimop/gempyor_pkg/src/gempyor/shared_cli.py
+++ b/flepimop/gempyor_pkg/src/gempyor/shared_cli.py
@@ -169,13 +169,11 @@ def click_helpstring(
         >>> @click_helpstring(opt)
         ... def test_cli(num: int) -> None:
         ...     print(f"Your favorite number is {num}!")
-        ...
-        >>> print(test_cli.__doc__)
-
-
+        >>> print(test_cli.__doc__)  # doctest: +SKIP
         Command Line Interface arguments:
+        <BLANKLINE>
+           n: Int
 
-        n: Int
     """
     if not isinstance(params, list):
         params = [params]
@@ -334,24 +332,12 @@ def log_cli_inputs(kwargs: dict[str, Any], verbosity: int | None = None) -> None
 
     Examples:
         >>> from gempyor.shared_cli import log_cli_inputs
-        >>> log_cli_inputs({"abc": 123, "def": True}, 3)
+        >>> log_cli_inputs({"abc": 123, "def": True}, 3) # doctest: +SKIP
         2024-11-05 09:27:58,884:DEBUG:gempyor.shared_cli> CLI was given 2 arguments:
         2024-11-05 09:27:58,885:DEBUG:gempyor.shared_cli> abc = 123.
         2024-11-05 09:27:58,885:DEBUG:gempyor.shared_cli> def = True.
         >>> log_cli_inputs({"abc": 123, "def": True}, 2)
-        >>> from pathlib import Path
-        >>> kwargs = {
-        ...     "input_file": Path("config.in"),
-        ...     "method": "stochastic",
-        ...     "cluster": "longleaf",
-        ...     "verbosity": 3,
-        ... }
-        >>> log_cli_inputs(kwargs)
-        2024-11-05 09:29:21,666:DEBUG:gempyor.shared_cli> CLI was given 4 arguments:
-        2024-11-05 09:29:21,667:DEBUG:gempyor.shared_cli> input_file = /Users/twillard/Desktop/GitHub/HopkinsIDD/flepiMoP/flepimop/gempyor_pkg/config.in.
-        2024-11-05 09:29:21,667:DEBUG:gempyor.shared_cli> method = stochastic.
-        2024-11-05 09:29:21,668:DEBUG:gempyor.shared_cli> cluster    = longleaf.
-        2024-11-05 09:29:21,668:DEBUG:gempyor.shared_cli> verbosity  = 3.
+
     """
     verbosity = kwargs.get("verbosity") if verbosity is None else verbosity
     if verbosity is None:

--- a/flepimop/gempyor_pkg/src/gempyor/sync/_sync.py
+++ b/flepimop/gempyor_pkg/src/gempyor/sync/_sync.py
@@ -181,10 +181,8 @@ def _rsync_ensure_path(target: str, verbosity: int, dry_run: bool) -> CompletedP
     Examples:
         >>> from gempyor.sync._sync import _rsync_ensure_path
         >>> _rsync_ensure_path("/foo/bar", 0, True)
-        (DRY RUN): mkdir -p /foo/bar
         CompletedProcess(args=['echo', '(DRY RUN): mkdir -p /foo/bar'], returncode=0)
         >>> _rsync_ensure_path("user@host:/fizz/buzz", 0, True)
-        (DRY RUN): ssh user@host mkdir -p /fizz/buzz
         CompletedProcess(args=['echo', '(DRY RUN): ssh user@host mkdir -p /fizz/buzz'], returncode=0)
     """
     # pylint: enable=line-too-long
@@ -349,7 +347,7 @@ class S3SyncModel(SyncABC, WithFilters):
         Traceback (most recent call last):
             ...
         pydantic_core._pydantic_core.ValidationError: 1 validation error for S3SyncModel
-        Value error, At least one of `source` or `target` must be an s3 bucket, as indicated by a `s3://` prefix [type=value_error, input_value={'type': 's3sync', 'targe...et', 'source': 'source'}, input_type=dict]
+          Value error, At least one of `source` or `target` must be an s3 bucket, as indicated by a `s3://` prefix [type=value_error, input_value={'type': 's3sync', 'targe...et', 'source': 'source'}, input_type=dict]
             For further information visit https://errors.pydantic.dev/2.11/v/value_error
     """
     # pylint: enable=line-too-long

--- a/flepimop/gempyor_pkg/src/gempyor/testing.py
+++ b/flepimop/gempyor_pkg/src/gempyor/testing.py
@@ -304,7 +304,7 @@ def run_test_in_separate_process(
     Examples:
         Typically this function is used in a test like so:
 
-        >>> assert run_test_in_separate_process(
+        >>> assert run_test_in_separate_process( # doctest: +SKIP
         ...     Path(__file__).parent / "external_script.py",
         ...     tmp_path / "test.py",
         ...     args=["arg1", "arg2"],

--- a/flepimop/gempyor_pkg/src/gempyor/utils.py
+++ b/flepimop/gempyor_pkg/src/gempyor/utils.py
@@ -188,18 +188,6 @@ def search_and_import_plugins_class(
     Returns:
         The instance of the class that was instantiated with provided **kwargs.
 
-    Examples:
-        Suppose there is a module called `my_plugin.py with a class `MyClass` located at `/path/to/plugin/`.
-
-        Dynamically import and instantiate the class:
-
-        >>> instance = search_and_import_plugins_class('/path/to/plugin', path_prefix, 'MyClass', **params)
-
-        View the instance:
-
-        >>> print(instance)
-        <__main__.MyClass object at 0x7f8b2c6b4d60>
-
     """
     # Look for all possible plugins and import them
     # https://stackoverflow.com/questions/67631/how-can-i-import-a-module-dynamically-given-the-full-path
@@ -253,14 +241,6 @@ def profile(
     Returns:
         Profile of the decorated function.
 
-    Examples:
-        >>> @profile(output_file="my_function.prof")
-        >>> def my_function():
-            # Function body content
-            pass
-        >>> my_function()
-        After running ``my_function``, a file named ``my_function.prof`` will be created in the current WD.
-        This file contains the profiling data.
     """
 
     def inner(func):
@@ -373,18 +353,6 @@ def list_filenames(
     Returns:
         A list of strings representing the paths to the files that match the filters.
 
-    Examples:
-        To get all files containing "hosp":
-        >>> gempyor.utils.list_filenames(
-            folder="model_output/",
-            filters=["hosp"],
-        )
-
-        To get only "hosp" files with a ".parquet" extension:
-        >>> gempyor.utils.list_filenames(
-            folder="model_output/",
-            filters=["hosp", ".parquet"],
-        )
     """
     filters = [filters] if not isinstance(filters, list) else filters
     filters = filters if len(filters) else [""]
@@ -419,20 +387,11 @@ def extract_slot(file: Path) -> pd.DataFrame:
         >>> file = Path.cwd() / "00017.foobar.csv"
         >>> sample.to_csv(file, index=False)
         >>> extract_slot(file)
-        letters  slot
+          letters  slot
         0       a    17
         1       b    17
         2       c    17
-        >>> extract_slot(file).info()
-        <class 'pandas.core.frame.DataFrame'>
-        RangeIndex: 3 entries, 0 to 2
-        Data columns (total 2 columns):
-        #   Column   Non-Null Count  Dtype
-        ---  ------   --------------  -----
-        0   letters  3 non-null      object
-        1   slot     3 non-null      int64
-        dtypes: int64(1), object(1)
-        memory usage: 180.0+ bytes
+
     """
     df = pd.read_parquet(file) if file.suffix == ".parquet" else pd.read_csv(file)
     if "slot" in df.columns:
@@ -483,27 +442,27 @@ def rolling_mean_pad(
     Examples:
         Below is a brief set of examples showcasing how to smooth a metric, like
         hospitalizations, using this function.
-        ```
+
         >>> import numpy as np
         >>> from gempyor.utils import rolling_mean_pad
         >>> hospitalizations = np.arange(1., 29.).reshape((7, 4))
         >>> hospitalizations
         array([[ 1.,  2.,  3.,  4.],
-            [ 5.,  6.,  7.,  8.],
-            [ 9., 10., 11., 12.],
-            [13., 14., 15., 16.],
-            [17., 18., 19., 20.],
-            [21., 22., 23., 24.],
-            [25., 26., 27., 28.]])
+               [ 5.,  6.,  7.,  8.],
+               [ 9., 10., 11., 12.],
+               [13., 14., 15., 16.],
+               [17., 18., 19., 20.],
+               [21., 22., 23., 24.],
+               [25., 26., 27., 28.]])
         >>> rolling_mean_pad(hospitalizations, 5)
         array([[ 3.4,  4.4,  5.4,  6.4],
-            [ 5.8,  6.8,  7.8,  8.8],
-            [ 9. , 10. , 11. , 12. ],
-            [13. , 14. , 15. , 16. ],
-            [17. , 18. , 19. , 20. ],
-            [20.2, 21.2, 22.2, 23.2],
-            [22.6, 23.6, 24.6, 25.6]])
-        ```
+               [ 5.8,  6.8,  7.8,  8.8],
+               [ 9. , 10. , 11. , 12. ],
+               [13. , 14. , 15. , 16. ],
+               [17. , 18. , 19. , 20. ],
+               [20.2, 21.2, 22.2, 23.2],
+               [22.6, 23.6, 24.6, 25.6]])
+
     """
     weights = (1.0 / window) * np.ones(window)
     output = scipy.ndimage.convolve1d(data, weights, axis=0, mode="nearest")
@@ -580,17 +539,16 @@ def create_resume_out_filename(
         The path to a corresponding output file.
 
     Examples:
-        Generate an output file with specified parameters:
-        >>> filename = create_resume_out_filename(
-            flepi_run_index="test_run",
-            flepi_prefix="model_output/run_id/",
-            flepi_slot_index="1",
-            flepi_block_index="2",
-            filetype="seed",
-            liketype="chimeric"
-            )
-        >>> print(filename)
-        "experiment/001/normal/intermediate/000000123.000000000.1.parquet"
+        >>> from gempyor.utils import create_resume_out_filename
+        >>> create_resume_out_filename(
+        ...     flepi_run_index="test_run",
+        ...     flepi_prefix="model_output/run_id/",
+        ...     flepi_slot_index="1",
+        ...     flepi_block_index="2",
+        ...     filetype="seed",
+        ...     liketype="chimeric",
+        ... )
+        'model_output/model_output/run_id/test_run/seed/chimeric/intermediate/000000001.000000001.000000001.test_run.seed.csv'
     """
     prefix = f"{flepi_prefix}/{flepi_run_index}"
     inference_filepath_suffix = f"{liketype}/intermediate"
@@ -631,16 +589,15 @@ def create_resume_input_filename(
         The path to the a corresponding input file.
 
     Examples:
-        Generate an input file with specified parameters:
-        >>> filename = create_resume_input_filename(
-            resume_run_index="2",
-            flepi_prefix="model_output/run_id/",
-            flepi_slot_index="1",
-            filetype="seed",
-            liketype="chimeric"
-            )
-        >>> print(filename)
-        "experiment/002/normal/final/789.csv"
+        >>> from gempyor.utils import create_resume_input_filename
+        >>> create_resume_input_filename(
+        ...     resume_run_index="2",
+        ...     flepi_prefix="model_output/run_id/",
+        ...     flepi_slot_index="1",
+        ...     filetype="seed",
+        ...     liketype="chimeric",
+        ... )
+        'model_output/model_output/run_id/2/seed/chimeric/final/000000001.2.seed.csv'
     """
     prefix = f"{flepi_prefix}/{resume_run_index}"
     inference_filepath_suffix = f"{liketype}/final"
@@ -676,14 +633,20 @@ def get_filetype_for_resume(
 
     Examples:
         Determine file types for block index 1 with seeding data NOT discarded:
-        >>> filetypes = get_filetype_for_resume(resume_discard_seeding="false", flepi_block_index="1")
-        >>> print(filetypes)
-        ["seed", "spar", "snpi", "hpar", "hnpi", "init"]
+
+        >>> from gempyor.utils import get_filetype_for_resume
+        >>> get_filetype_for_resume(
+        ...     resume_discard_seeding="false", flepi_block_index="1"
+        ... )
+        ['seed', 'spar', 'snpi', 'hpar', 'hnpi', 'init']
 
         Determine file types for block index 2 with seeding data discarded:
-        >>> filtypes = get_filetype_for_resume(resume_discard_seeding="true", flepi_block_index="2")
-        >>> print(filetypes)
-        ["seed", "spar", "snpi", "hpar", "hnpi", "host", "llik", "init"]
+
+        >>> get_filetype_for_resume(
+        ...     resume_discard_seeding="true", flepi_block_index="2"
+        ... )
+        ['seed', 'spar', 'snpi', 'hpar', 'hnpi', 'host', 'llik', 'init']
+
     """
     if flepi_block_index == "1":
         if resume_discard_seeding == "true":
@@ -704,13 +667,18 @@ def create_resume_file_names_map(
     last_job_output: str,
 ) -> dict[str, str]:
     """
-    Generates a mapping of input file names to output file names for a resume process based on
-    parquet file types and environmental conditions. The function adjusts the file name mappings
-    based on the operational block index and the location of the last job output.
+    Generate a mapping of input file names to output file names for a resume process.
+
+    Generates a mapping of input file names to output file names for a resume process
+    based on parquet file types and environmental conditions. The function adjusts the
+    file name mappings based on the operational block index and the location of the
+    last job output.
 
     Args:
-        resume_discard_seeding:  Determines whether seeding-related file types should be included.
-        flepi_block_index: Determines a specific operational mode or block of the process.
+        resume_discard_seeding:  Determines whether seeding-related file types should
+            be included.
+        flepi_block_index: Determines a specific operational mode or block of the
+            process.
         resume_run_index: Resume run index.
         flepi_prefix: File prefix.
         flepi_slot_index: Index of the slot.
@@ -722,40 +690,49 @@ def create_resume_file_names_map(
         output file paths.
 
     The mappings depend on:
-    - Parquet file types appropriate for resuming a process, as determined by the environment.
-    - Whether the files are for 'global' or 'chimeric' types, as these liketypes influence the
-      file naming convention.
-    - The operational block index ('FLEPI_BLOCK_INDEX'), which can alter the input file names for
-      block index '1'.
-    - The presence and value of 'LAST_JOB_OUTPUT' environment variable, which if set to an S3 path,
-      adjusts the keys in the mapping to be prefixed with this path.
+    - Parquet file types appropriate for resuming a process, as determined by the
+        environment.
+    - Whether the files are for 'global' or 'chimeric' types, as these like types
+        influence the file naming convention.
+    - The operational block index ('FLEPI_BLOCK_INDEX'), which can alter the input
+        file names for block index '1'.
+    - The presence and value of 'LAST_JOB_OUTPUT' environment variable, which if set
+        to an S3 path, adjusts the keys in the mapping to be prefixed with this path.
 
     Raises:
-        No explicit exceptions are raised within the function, but it relies heavily on external
-        functions and environment variables which if improperly configured could lead to unexpected
-        behavior.
+        No explicit exceptions are raised within the function, but it relies heavily
+        on external functions and environment variables which if improperly configured
+        could lead to unexpected behavior.
 
     Examples:
-        Generate a mapping of file names for a given resume process:
+        >>> from pprint import pprint
+        >>> from gempyor.utils import create_resume_file_names_map
         >>> file_names_map = create_resume_file_names_map(
-            resume_discard_seeding="false",
-            flepi_block_index="1",
-            resume_run_index="1",
-            flepi_prefix="model_output/run_id/",
-            flepi_slot_index="1",
-            flepi_run_index="test_run",
-            last_job_output="s3://bucket/path/")
-        >>> print(file_names_map)
-        {
-        's3://bucket/path/model_output/run_id/1_type1_global_1.in': 'model_output/run_id/test_run_type1_global_1_1.out',
-        's3://bucket/path/model_output/run_id/1_type1_chimeric_1.in': 'model_output/run_id/test_run_type1_chimeric_1_1.out',
-        's3://bucket/path/model_output/run_id/1_type2_global_1.in': 'model_output/run_id/test_run_type2_global_1_1.out',
-        's3://bucket/path/model_output/run_id/1_type2_chimeric_1.in': 'model_output/run_id/test_run_type2_chimeric_1_1.out'
-        }
-        # Note: this output is toy output implemented with toy file names.
+        ...     resume_discard_seeding="false",
+        ...     flepi_block_index="1",
+        ...     resume_run_index="1",
+        ...     flepi_prefix="model_output/run_id/",
+        ...     flepi_slot_index="1",
+        ...     flepi_run_index="test_run",
+        ...     last_job_output="s3://bucket/path/",
+        ... )
+        >>> pprint(file_names_map)
+        {'s3://bucket/path/model_output/model_output/run_id/1/hnpi/chimeric/final/000000001.1.hnpi.parquet': 'model_output/model_output/run_id/test_run/hnpi/chimeric/intermediate/000000001.000000001.000000000.test_run.hnpi.parquet',
+         's3://bucket/path/model_output/model_output/run_id/1/hnpi/global/final/000000001.1.hnpi.parquet': 'model_output/model_output/run_id/test_run/hnpi/global/intermediate/000000001.000000001.000000000.test_run.hnpi.parquet',
+         's3://bucket/path/model_output/model_output/run_id/1/hpar/chimeric/final/000000001.1.hpar.parquet': 'model_output/model_output/run_id/test_run/hpar/chimeric/intermediate/000000001.000000001.000000000.test_run.hpar.parquet',
+         's3://bucket/path/model_output/model_output/run_id/1/hpar/global/final/000000001.1.hpar.parquet': 'model_output/model_output/run_id/test_run/hpar/global/intermediate/000000001.000000001.000000000.test_run.hpar.parquet',
+         's3://bucket/path/model_output/model_output/run_id/1/init/chimeric/final/000000001.1.init.parquet': 'model_output/model_output/run_id/test_run/init/chimeric/intermediate/000000001.000000001.000000000.test_run.init.parquet',
+         's3://bucket/path/model_output/model_output/run_id/1/init/global/final/000000001.1.init.parquet': 'model_output/model_output/run_id/test_run/init/global/intermediate/000000001.000000001.000000000.test_run.init.parquet',
+         's3://bucket/path/model_output/model_output/run_id/1/seed/chimeric/final/000000001.1.seed.csv': 'model_output/model_output/run_id/test_run/seed/chimeric/intermediate/000000001.000000001.000000000.test_run.seed.csv',
+         's3://bucket/path/model_output/model_output/run_id/1/seed/global/final/000000001.1.seed.csv': 'model_output/model_output/run_id/test_run/seed/global/intermediate/000000001.000000001.000000000.test_run.seed.csv',
+         's3://bucket/path/model_output/model_output/run_id/1/snpi/chimeric/final/000000001.1.snpi.parquet': 'model_output/model_output/run_id/test_run/snpi/chimeric/intermediate/000000001.000000001.000000000.test_run.snpi.parquet',
+         's3://bucket/path/model_output/model_output/run_id/1/snpi/global/final/000000001.1.snpi.parquet': 'model_output/model_output/run_id/test_run/snpi/global/intermediate/000000001.000000001.000000000.test_run.snpi.parquet',
+         's3://bucket/path/model_output/model_output/run_id/1/spar/chimeric/final/000000001.1.spar.parquet': 'model_output/model_output/run_id/test_run/spar/chimeric/intermediate/000000001.000000001.000000000.test_run.spar.parquet',
+         's3://bucket/path/model_output/model_output/run_id/1/spar/global/final/000000001.1.spar.parquet': 'model_output/model_output/run_id/test_run/spar/global/intermediate/000000001.000000001.000000000.test_run.spar.parquet'}
 
     Notes:
-        - The paths may be modified by the 'LAST_JOB_OUTPUT' if it is set and points to an S3 location.
+        - The paths may be modified by the 'LAST_JOB_OUTPUT' if it is set and points to
+        an S3 location.
     """
     file_types = get_filetype_for_resume(
         resume_discard_seeding=resume_discard_seeding, flepi_block_index=flepi_block_index
@@ -813,21 +790,6 @@ def download_file_from_s3(name_map: dict[str, str]) -> None:
         ClientError: If an error occurs during the download from S3, such as a permissions issue,
                      a missing file, or network-related errors. These are caught and logged but not
                      re-raised, to allow the function to attempt subsequent downloads.
-
-    Examples:
-        >>> name_map = {
-            "s3://mybucket/data/file1.txt": "/local/path/to/file1.txt",
-            "s3://mybucket/data/file2.txt": "/local/path/to/file2.txt"
-        }
-        >>> download_file_from_s3(name_map)
-        # This would download 'file1.txt' and 'file2.txt' from 'mybucket' on S3 to the specified local paths.
-
-        # If an S3 URI is malformed:
-        >>> name_map = {
-            "http://wrongurl.com/data/file1.txt": "/local/path/to/file1.txt"
-        }
-        >>> download_file_from_s3(name_map)
-        # This will raise a ValueError indicating the invalid S3 URI format.
     """
     try:
         import boto3
@@ -922,6 +884,7 @@ def _dump_formatted_yaml(cfg: confuse.Configuration) -> str:
                 rate: ["beta * gamma"]
                 proportional_to: [[S], [I]]
                 proportion_exponent: [1, 1]
+        <BLANKLINE>
     """
 
     class CustomDumper(yaml.Dumper):
@@ -1004,9 +967,13 @@ def _git_head(repository: Path) -> str:
 
     Examples:
         >>> import os
+        >>> import pytest
+        >>> if os.environ.get("FLEPI_PATH") is None:
+        ...     pytest.skip("FLEPI_PATH environment variable is not set.")
         >>> from pathlib import Path
-        >>> _git_head(Path(os.environ["FLEPI_PATH"]))
-        'efe896b1a5e4f8e33667c170cd5319d6ef1e3db5'
+        >>> _git_head(Path(os.environ["FLEPI_PATH"]))  # doctest: +ELLIPSIS
+        '...'
+
     """
     git_cmd = _shutil_which("git")
     proc = subprocess.run(
@@ -1027,10 +994,10 @@ def _git_checkout(repository: Path, branch: str) -> subprocess.CompletedProcess:
             checkout a new branch in.
         branch: The name of the new branch to checkout.
 
-    Examples:
-        >>> import os
-        >>> from pathlib import Path
-        >>> _git_checkout(Path(os.environ["FLEPI_PATH"]), "my-new-branch")
+    Returns:
+        A `subprocess.CompletedProcess` object containing the result of the checkout
+        command.
+
     """
     git_cmd = _shutil_which("git")
     return subprocess.run(
@@ -1073,7 +1040,7 @@ def _format_cli_options(
         >>> _format_cli_options({"o": "/path/to/output.log"})
         ['-o=/path/to/output.log']
         >>> _format_cli_options({"opt1": "```", "opt2": "$( echo 'Hello!')"})
-        ["--opt1='```'", '--opt2=\'$( echo \'"\'"\'Hello!\'"\'"\')\'']
+        ["--opt1='```'", '--opt2=\\'$( echo \\'"\\'"\\'Hello!\\'"\\'"\\')\\'']
         >>> _format_cli_options({"output": "/path/to/output.log"}, always_single=True)
         ['-output=/path/to/output.log']
         >>> _format_cli_options({"person": ["Alice", "Bob", "Charlie"]})


### PR DESCRIPTION
### Describe your changes.

This pull request:

- Switches the GitHub actions CI to use a unified conda install done via the `./bin/flepimop-install-dev` script which closely replicates user installation and enables cache sharing across GitHub action workflows, #475.
- Enables doctest for `gempyor`, #563.
- Also upped the min pylint score from 4 to 5, the latest score from CI was a 7.08 (https://github.com/HopkinsIDD/flepiMoP/actions/runs/16377836820/job/46282026928?pr=581).
- Updated the formatting of the produced `environment.yml` file to be more friendly for IDEs, #485.
- Removed the push trigger on the `dev` branch, in theory sounded like a good idea but in practice results in actions running twice when we have a release PR open.
- Made the slow unit tests for `gempyor` run as a dependent job of the fast tests and only run with one python version.
- Spun out R package installer script into a standalone script for modularization and to assist with R package development.

### Does this pull request make any user interface changes? If so please describe.

Those are reflected in updates to the documentation in `python-guidelines-for-developers.md`.

### What does your pull request address? Tag relevant issues.

This pull request addresses #475, #563.
