### PR TITLE
Allow Explicit 0 Mobility

### DIFF
--- a/flepimop/gempyor_pkg/src/gempyor/subpopulation_structure.py
+++ b/flepimop/gempyor_pkg/src/gempyor/subpopulation_structure.py
@@ -133,7 +133,7 @@ class GeodataFileTable(RootModel):
     root: list[GeodataFileRow]
 
     @model_validator(mode="after")
-    def subpop_is_primary_key(self) -> "GeodataFileTable":
+    def _subpop_is_primary_key(self) -> "GeodataFileTable":
         """
         Validate that the subpopulation names are unique.
 
@@ -163,10 +163,10 @@ class MobilityFileRow(BaseModel):
 
     ori: str
     dest: str
-    amount: Annotated[int, Field(gt=0)]
+    amount: Annotated[int, Field(ge=0)]
 
     @model_validator(mode="after")
-    def ori_and_dest_are_different(self) -> "MobilityFileRow":
+    def _ori_and_dest_are_different(self) -> "MobilityFileRow":
         """
         Validate that the origin and destination subpopulation names are different.
 
@@ -194,7 +194,7 @@ class MobilityFileTable(RootModel):
     root: list[MobilityFileRow]
 
     @model_validator(mode="after")
-    def ori_and_dest_are_primary_key(self) -> "MobilityFileTable":
+    def _ori_and_dest_are_primary_key(self) -> "MobilityFileTable":
         """
         Validate that the origin and destination subpopulation names are unique.
 


### PR DESCRIPTION
### Describe your changes.

Prior to #549 providing an explicit mobility of 0 was allowed, this reallows this previous behaivor. Minor change to the `MobilityFileRow` pydantic model was required and then adjust ments to the unit tests. Should address #605.


### Does this pull request make any user interface changes? If so please describe.

The user interface changes are explicit mobility of 0 is now allowed.


### What does your pull request address? Tag relevant issues.

This pull request addresses #605.
