### PR TITLE
Fix typo in flepimop install URL

### DIFF
--- a/documentation/gitbook/how-to-run/quick-start-guide.md
+++ b/documentation/gitbook/how-to-run/quick-start-guide.md
@@ -28,7 +28,7 @@ This installation script is currently only designed for Linux/MacOS operating sy
 {% endhint %}
 
 ```shell
-$ curl -LsSf -o flepimop-install "https://raw.githubusercontent.com/HopkinsIDD/flepiMoP/refs/heads/main/bin/lint"
+$ curl -LsSf -o flepimop-install "https://raw.githubusercontent.com/HopkinsIDD/flepiMoP/refs/heads/main/bin/flepimop-install"
 $ chmod +x flepimop-install
 ```
 


### PR DESCRIPTION
### Describe your changes.

Corrected a typo in the quick start guide that was leading users to erroneously download and run the linting utility instead of the installation script.

### Does this pull request make any user interface changes? If so please describe.

The user interface changes are none.

### What does your pull request address? Tag relevant issues.

_n/a_
