### PR TITLE
fix typo in nbinom distribution

### DIFF
--- a/flepimop/gempyor_pkg/src/gempyor/statistics.py
+++ b/flepimop/gempyor_pkg/src/gempyor/statistics.py
@@ -265,7 +265,7 @@ class Statistic:
                 gt_data, loc=model_data, scale=self.params.get("sd", sd) * model_data
             ),  # scale = standard deviation
             # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
-            "nbinom": lambda gt_data, model_data, n, p: scipy.stats.nbinom.logpmf(
+            "nbinom": lambda gt_data, model_data, alpha: scipy.stats.nbinom.logpmf(
                 k=gt_data,
                 n=1.0 / self.params.get("alpha"),
                 p=1.0 / (1.0 + self.params.get("alpha") * model_data),

--- a/flepimop/gempyor_pkg/src/gempyor/statistics.py
+++ b/flepimop/gempyor_pkg/src/gempyor/statistics.py
@@ -267,8 +267,8 @@ class Statistic:
             # >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
             "nbinom": lambda gt_data, model_data, alpha: scipy.stats.nbinom.logpmf(
                 k=gt_data,
-                n=1.0 / self.params.get("alpha"),
-                p=1.0 / (1.0 + self.params.get("alpha") * model_data),
+                n=1.0 / alpha,
+                p=1.0 / (1.0 + alpha * model_data),
             ),
             "rmse": lambda gt_data, model_data: -np.log(
                 np.sqrt(np.nansum((gt_data - model_data) ** 2))


### PR DESCRIPTION
### Describe your changes.

This pull request edits a small typo to allow the nbinom likelihood to work within calibration. 


### Does this pull request make any user interface changes? If so please describe.

None,  just the config syntax would look something like
```
      likelihood:
        dist: nbinom
        params:
          alpha: 0.3
```
